### PR TITLE
binaryalert - rule cleanup and masscan addition

### DIFF
--- a/rules/public/public.yara
+++ b/rules/public/public.yara
@@ -36,11 +36,12 @@ rule jtesta_ssh_mitm
         reference = "https://github.com/jtesta/ssh-mitm"
         org = "Airbnb CSIRT"
         date = "2017-05-19"
+        fidelity = "high"
     strings:
         $a1 = "INTERCEPTED PASSWORD:" wide ascii
         $a2 = "more sshbuf problems." wide ascii
     condition:
-        any of ($a*)
+        all of ($a*)
 }
 
 rule macos_wirelurker
@@ -50,17 +51,19 @@ rule macos_wirelurker
         description = "Wirelurker Malware"
         reference = "https://www.paloaltonetworks.com/apps/pan/public/downloadResource?pagePath=/content/pan/en_US/resources/research/unit42-wirelurker-a-new-era-in-ios-and-os-x-malware"
         org = "Airbnb CSIRT"
+        fidelity = "medium"
     strings:
-        $a1 = "/usr/local/machook/" nocase wide ascii
-        $a2 = "/usr/local/Resources/start.sh" nocase wide ascii
-        $a3 = "/usr/local/Resources/FontMap1.cfg" nocase wide ascii
+        $a1 = "/usr/local/machook/" wide ascii
+        $a2 = "/usr/local/Resources/start.sh" wide ascii
+        $a3 = "/usr/local/Resources/FontMap1.cfg" wide ascii
         $a4 = "/Users/Shared/start.sh" nocase wide ascii
-        $a5 = "com.apple.machook_damon.plist" nocase wide ascii
-        $a6 = "com.apple.globalupdate.plist" nocase wide ascii
-        $a7 = ".comeinbaby.com/" nocase wide ascii
-        $a8 = "/tmp/machook.log" nocase wide ascii
+        $a5 = "com.apple.machook_damon.plist" wide ascii
+        $a6 = "com.apple.globalupdate.plist" wide ascii
+        $a7 = "/tmp/machook.log" wide ascii
+        $n1 = "/var/db/.MRTReady" fullword wide ascii
+        $n2 = "MRT.CertificateRemediation" fullword wide ascii
     condition:
-        MachO and any of ($a*)
+        MachO and any of ($a*) and not any of ($n*)
 }
 
 rule multiOS_pupy_rat
@@ -70,15 +73,16 @@ rule multiOS_pupy_rat
         description = "pupy - opensource cross platform rat and post-exploitation tool"
         reference = "https://github.com/n1nj4sec/pupy"
         org = "Airbnb CSIRT"
+        fidelity = "high"
     strings:
-        $a1 = "dumping lsa secrets"  nocase wide ascii
-        $a2 = "dumping cached domain passwords"  nocase wide ascii
+        $a1 = "dumping lsa secrets" nocase wide ascii
+        $a2 = "dumping cached domain passwords" nocase wide ascii
         $a3 = "the keylogger is already started" nocase wide ascii
-        $a4 = "pupyutils.dns" nocase wide ascii
-        $a5 = "pupwinutils.security" nocase wide ascii
-        $a6 = "-PUPY_CONFIG_COMES_HERE-" nocase wide ascii
+        $a4 = "pupyutils.dns" wide ascii
+        $a5 = "pupwinutils.security" wide ascii
+        $a6 = "-PUPY_CONFIG_COMES_HERE-" wide ascii
     condition:
-        any of ($a*)
+        2 of ($a*)
 }
 
 rule windows_ransomware_wannacry
@@ -89,19 +93,40 @@ rule windows_ransomware_wannacry
         reference = "https://securelist.com/blog/incidents/78351/wannacry-ransomware-used-in-widespread-attacks-all-over-the-world/"
         org = "Airbnb CSIRT"
         md5 = "4fef5e34143e646dbf9907c4374276f5"
+        fidelity = "medium"
     strings:
         // generic
-        $a1 = "msg/m_chinese" nocase wide ascii
-        $a2 = ".wnry" nocase wide ascii
-        $a3 = "attrib +h" nocase wide ascii
+        $a1 = "msg/m_chinese" wide ascii
+        $a2 = ".wnry" wide ascii
+        $a3 = "attrib +h" wide ascii
         // unique malware strings
-        $b1 = "WNcry@2ol7" nocase wide ascii
+        $b1 = "WNcry@2ol7" wide ascii
         // c2
-        $b2 = "iuqerfsodp9ifjaposdfjhgosurijfaewrwergwea.com" nocase wide ascii
+        $b2 = "iuqerfsodp9ifjaposdfjhgosurijfaewrwergwea.com" wide ascii
         // bitcoin addresses
-        $b3 = "115p7UMMngoj1pMvkpHijcRdfJNXj6LrLn" nocase wide ascii
-        $b4 = "12t9YDPgwueZ9NyMgw519p7AA8isjr6SMw" nocase wide ascii
-        $b5 = "13AM4VW2dhxYgXeQepoHkHSQuy6NgaEb94" nocase wide ascii
+        $b3 = "115p7UMMngoj1pMvkpHijcRdfJNXj6LrLn" wide ascii
+        $b4 = "12t9YDPgwueZ9NyMgw519p7AA8isjr6SMw" wide ascii
+        $b5 = "13AM4VW2dhxYgXeQepoHkHSQuy6NgaEb94" wide ascii
+    condition:
+        all of ($a*) or any of ($b*)
+}
+
+rule hacktool_masscan
+{
+    meta:
+        date = "2017-07-27"
+        description = "masscan is a performant port scanner, it produces results similar to nmap"
+        reference = "https://github.com/robertdavidgraham/masscan"
+        org = "Airbnb CSIRT"
+        fidelity = "high"
+    strings:
+        $a1 = "EHLO masscan" fullword wide ascii
+        $a2 = "User-Agent: masscan/" wide ascii
+        $a3 = "/etc/masscan/masscan.conf" fullword wide ascii
+        $b1 = "nmap(%s): unsupported. This code will never do DNS lookups." wide ascii
+        $b2 = "nmap(%s): unsupported, we do timing WAY different than nmap" wide ascii
+        $b3 = "[hint] I've got some local priv escalation 0days that might work" wide ascii
+        $b4 = "[hint] VMware on Macintosh doesn't support masscan" wide ascii
     condition:
         all of ($a*) or any of ($b*)
 }


### PR DESCRIPTION
to: @airbnb/binaryalert-maintainers 

**Changes**

1. Added `fidelity` key
2. Tightened `jtesta_ssh_mitm` - 2 conditions now
3. TIghtended `macos_wirelurker` - remove domain condition and address MRT fp's
4. Remove improper uses of `nocase`
5. Add coverage for masscan via `hacktool_masscan`
6. Remove extra spacing that didn't need to exist

Better Yara rule organization will come in a future PR

**Testing**

`yara public.yara ...`