### PR TITLE
[OUTPUT] Flatten SNS alert for better PagerDuty formatting

### DIFF
--- a/lambda_functions/analyzer/binary_info.py
+++ b/lambda_functions/analyzer/binary_info.py
@@ -97,7 +97,7 @@ class BinaryInfo(object):
 
     def summary(self):
         """Generate a summary dictionary of binary attributes."""
-        return {
+        result = {
             'FileInfo': {
                 'ComputedMD5': self.computed_md5,
                 'ComputedSHA256': self.computed_sha,
@@ -105,15 +105,16 @@ class BinaryInfo(object):
                 'S3Location': self.s3_identifier,
                 'SamplePath': self.observed_path
             },
-            'MatchedRules': [
-                {
-                    # YARA string IDs, e.g. "$string1"
-                    'MatchedStrings': list(sorted(set(t[1] for t in match.strings))),
-                    'Meta': match.meta,
-                    'RuleFile': match.namespace,
-                    'RuleName': match.rule,
-                    'RuleTags': match.tags
-                }
-                for match in self.yara_matches
-            ]
+            'NumMatchedRules': len(self.yara_matches)
         }
+
+        for index, match in enumerate(self.yara_matches, start=1):
+            result['MatchedRule{}'.format(index)] = {
+                # YARA string IDs, e.g. "$string1"
+                'MatchedStrings': list(sorted(set(t[1] for t in match.strings))),
+                'Meta': match.meta,
+                'RuleFile': match.namespace,
+                'RuleName': match.rule,
+                'RuleTags': match.tags
+            }
+        return result

--- a/tests/lambda_functions/analyzer/main_test.py
+++ b/tests/lambda_functions/analyzer/main_test.py
@@ -116,7 +116,8 @@ class MainTest(fake_filesystem_unittest.TestCase):
                     'S3Location': s3_id,
                     'SamplePath': MOCK_FILE_METADATA['observed_path']
                 },
-                'MatchedRules': [
+
+                'MatchedRule':
                     {
                         'MatchedStrings': ['$evil_string'],
                         'Meta': {
@@ -135,7 +136,6 @@ class MainTest(fake_filesystem_unittest.TestCase):
                         'RuleName': 'extension_is_exe',
                         'RuleTags': ['mock_rule']
                     }
-                ]
             }
         }
         self.assertEqual(expected, result)

--- a/tests/lambda_functions/analyzer/main_test.py
+++ b/tests/lambda_functions/analyzer/main_test.py
@@ -116,9 +116,8 @@ class MainTest(fake_filesystem_unittest.TestCase):
                     'S3Location': s3_id,
                     'SamplePath': MOCK_FILE_METADATA['observed_path']
                 },
-
-                'MatchedRule':
-                {
+                'NumMatchedRules': 2,
+                'MatchedRule1': {
                     'MatchedStrings': ['$evil_string'],
                     'Meta': {
                         'author': 'Austin Byers',
@@ -129,7 +128,7 @@ class MainTest(fake_filesystem_unittest.TestCase):
                     'RuleName': 'contains_evil',
                     'RuleTags': ['mock_rule', 'has_meta']
                 },
-                {
+                'MatchedRule2': {
                     'MatchedStrings': [],
                     'Meta': {},
                     'RuleFile': 'externals.yar',
@@ -138,7 +137,6 @@ class MainTest(fake_filesystem_unittest.TestCase):
                 }
             }
         }
-
 
         self.assertEqual(expected, result)
 
@@ -187,19 +185,18 @@ class MainTest(fake_filesystem_unittest.TestCase):
                     'S3Location': 'S3:{}:KEY2'.format(MOCK_S3_BUCKET_NAME),
                     'SamplePath': ''
                 },
-                'MatchedRules': [
-                    {
-                        'MatchedStrings': ['$evil_string'],
-                        'Meta': {
-                            'author': 'Austin Byers',
-                            'description': ('A helpful description about why this rule matches '
-                                            'dastardly evil files.')
-                        },
-                        'RuleFile': 'evil_check.yar',
-                        'RuleName': 'contains_evil',
-                        'RuleTags': ['mock_rule', 'has_meta']
-                    }
-                ]
+                'NumMatchedRules': 1,
+                'MatchedRule1': {
+                    'MatchedStrings': ['$evil_string'],
+                    'Meta': {
+                        'author': 'Austin Byers',
+                        'description': ('A helpful description about why this rule matches '
+                                        'dastardly evil files.')
+                    },
+                    'RuleFile': 'evil_check.yar',
+                    'RuleName': 'contains_evil',
+                    'RuleTags': ['mock_rule', 'has_meta']
+                }
             },
             'S3:{}:KEY3'.format(MOCK_S3_BUCKET_NAME): {
                 'FileInfo': {
@@ -209,15 +206,14 @@ class MainTest(fake_filesystem_unittest.TestCase):
                     'S3Location': 'S3:{}:KEY3'.format(MOCK_S3_BUCKET_NAME),
                     'SamplePath': 'win32'
                 },
-                'MatchedRules': [
-                    {
-                        'MatchedStrings': [],
-                        'Meta': {},
-                        'RuleFile': 'externals.yar',
-                        'RuleName': 'filename_contains_win32',
-                        'RuleTags': ['mock_rule']
-                    }
-                ]
+                'NumMatchedRules': 1,
+                'MatchedRule1': {
+                    'MatchedStrings': [],
+                    'Meta': {},
+                    'RuleFile': 'externals.yar',
+                    'RuleName': 'filename_contains_win32',
+                    'RuleTags': ['mock_rule']
+                }
             }
         }
         self.assertEqual(expected, result)

--- a/tests/lambda_functions/analyzer/main_test.py
+++ b/tests/lambda_functions/analyzer/main_test.py
@@ -118,26 +118,28 @@ class MainTest(fake_filesystem_unittest.TestCase):
                 },
 
                 'MatchedRule':
-                    {
-                        'MatchedStrings': ['$evil_string'],
-                        'Meta': {
-                            'author': 'Austin Byers',
-                            'description': ('A helpful description about why this rule matches '
-                                            'dastardly evil files.')
-                        },
-                        'RuleFile': 'evil_check.yar',
-                        'RuleName': 'contains_evil',
-                        'RuleTags': ['mock_rule', 'has_meta']
+                {
+                    'MatchedStrings': ['$evil_string'],
+                    'Meta': {
+                        'author': 'Austin Byers',
+                        'description': ('A helpful description about why this rule matches '
+                                        'dastardly evil files.')
                     },
-                    {
-                        'MatchedStrings': [],
-                        'Meta': {},
-                        'RuleFile': 'externals.yar',
-                        'RuleName': 'extension_is_exe',
-                        'RuleTags': ['mock_rule']
-                    }
+                    'RuleFile': 'evil_check.yar',
+                    'RuleName': 'contains_evil',
+                    'RuleTags': ['mock_rule', 'has_meta']
+                },
+                {
+                    'MatchedStrings': [],
+                    'Meta': {},
+                    'RuleFile': 'externals.yar',
+                    'RuleName': 'extension_is_exe',
+                    'RuleTags': ['mock_rule']
+                }
             }
         }
+
+
         self.assertEqual(expected, result)
 
         # Verify that the return value can be encoded as JSON.


### PR DESCRIPTION
This PR aims to resolve issue: #24 

**What:**
- Information about each matched rule now a top-level key
- Total number of matches are displayed

**Why:**
- Formatting change should make the output in PagerDuty easier to read.