### PR TITLE
Force-remove mocks after tests to fix batcher invocation during deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ information about adding and updating YARA rules.
 
 ## Updating Pip Packages
 The exact `pip3` package versions used are frozen in
-[`requirements.txt`](requirements_top_level.txt). However, to make upgrading packages easier,
+[`requirements.txt`](requirements.txt). However, to make upgrading packages easier,
 [`requirements_top_level.txt`](requirements_top_level.txt) contains only the top-level packages
 required by BinaryAlert. To upgrade the package requirements,
 

--- a/manage.py
+++ b/manage.py
@@ -16,6 +16,7 @@ import hcl
 from lambda_functions.analyzer.main import COMPILED_RULES_FILENAME
 from rules.compile_rules import compile_rules
 from rules.update_rules import update_github_rules
+from tests import boto3_mocks
 
 PROJECT_DIR = os.path.dirname(os.path.realpath(__file__))  # Directory containing this file.
 TERRAFORM_DIR = os.path.join(PROJECT_DIR, 'terraform')
@@ -58,6 +59,7 @@ def deploy():
     analyze_all()
 
 
+@boto3_mocks.restore_http_adapter
 def test():
     """Run all *_test.py unittests and exit 1 if tests failed."""
     suite = unittest.TestLoader().discover(PROJECT_DIR, pattern='*_test.py')

--- a/terraform/cloudwatch_metric_alarm.tf
+++ b/terraform/cloudwatch_metric_alarm.tf
@@ -113,7 +113,7 @@ Read or write requests to the DynamoDB table are being throttled.
 EOF
 
   namespace   = "AWS/DynamoDB"
-  metric_name = "ReadThrottleEvents"
+  metric_name = "ThrottledRequests"
   statistic   = "Sum"
 
   dimensions = {

--- a/tests/boto3_mocks.py
+++ b/tests/boto3_mocks.py
@@ -5,6 +5,20 @@
 import collections
 import io
 
+from botocore.vendored.requests.adapters import HTTPAdapter
+
+
+def restore_http_adapter(func):
+    """Decorator to manually restore the botocore adapter which moto does not always restore."""
+    # Due to https://github.com/spulec/moto/issues/1026, mocks are not always properly stopped.
+    # This manually restores the mocked out HTTPAdapter library.
+
+    def func_wrapper():
+        real_adapter_send = HTTPAdapter.send
+        func()
+        HTTPAdapter.send = real_adapter_send
+    return func_wrapper
+
 
 class MockLambdaContext(object):
     """http://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html"""

--- a/tests/boto3_mocks.py
+++ b/tests/boto3_mocks.py
@@ -9,11 +9,12 @@ from botocore.vendored.requests.adapters import HTTPAdapter
 
 
 def restore_http_adapter(func):
-    """Decorator to manually restore the botocore adapter which moto does not always restore."""
+    """Decorator to manually restore the botocore adapter in cases where moto does not."""
     # Due to https://github.com/spulec/moto/issues/1026, mocks are not always properly stopped.
     # This manually restores the mocked out HTTPAdapter library.
 
     def func_wrapper():
+        """Remember HTTPAdapter.send before invoking the wrapped function."""
         real_adapter_send = HTTPAdapter.send
         func()
         HTTPAdapter.send = real_adapter_send


### PR DESCRIPTION
After #28 introduced `moto` to the unit test framework, the batcher invocation during `python3 manage.py deploy` breaks with an error like the following:

```
requests.exceptions.ConnectionError: Connection refused: POST https://lambda.REGION.amazonaws.com/2015-03-31/functions/FUNCTION_NAME
```

Due to https://github.com/spulec/moto/issues/1026, `moto` mocks are not always restored correctly. This means that after the unit tests run, part of `boto3` was still mocked out.

As a simple workaround, I've added a decorator which manually restores the underlying `HTTPAdapter` after running the unit test suite.

## Other Minor Changes
- Fixes a link in README
- Fixes Dynamo metric alarm to reference generic `ThrottledRequests` instead of `ReadThrottleEvents` specifically

## Tested
CI and deployed to an empty test account. Batcher invocation was successful during the test deploy.

## Reviewers
to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers 