### PR TITLE
Refactor manage.py

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -136,7 +136,7 @@ function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
+good-names=f,i,j,k,ex,Run,_
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no

--- a/lambda_functions/build.py
+++ b/lambda_functions/build.py
@@ -1,0 +1,70 @@
+"""Builds the deployment packages for all of the Lambda functions."""
+import glob
+import os
+import shutil
+import tempfile
+import zipfile
+
+from lambda_functions.analyzer.main import COMPILED_RULES_FILENAME
+from rules.compile_rules import compile_rules
+
+LAMBDA_DIR = os.path.dirname(os.path.realpath(__file__))
+
+ANALYZE_SOURCE = os.path.join(LAMBDA_DIR, 'analyzer')
+ANALYZE_DEPENDENCIES = os.path.join(ANALYZE_SOURCE, 'yara_python_3.6.3.zip')
+ANALYZE_ZIPFILE = 'lambda_analyzer'  # ".zip" will be added later
+
+BATCH_SOURCE = os.path.join(LAMBDA_DIR, 'batcher', 'main.py')
+BATCH_ZIPFILE = 'lambda_batcher.zip'
+
+DISPATCH_SOURCE = os.path.join(LAMBDA_DIR, 'dispatcher', 'main.py')
+DISPATCH_ZIPFILE = 'lambda_dispatcher.zip'
+
+
+def _build_analyzer(target_directory):
+    """Build the YARA analyzer Lambda deployment package."""
+    print('Creating analyzer deploy package...')
+
+    # Create a new copy of the core lambda directory to avoid cluttering the original.
+    temp_package_dir = os.path.join(tempfile.gettempdir(), 'tmp_yara_analyzer.pkg')
+    if os.path.exists(temp_package_dir):
+        shutil.rmtree(temp_package_dir)
+    os.mkdir(temp_package_dir)
+    for py_file in glob.glob(os.path.join(ANALYZE_SOURCE, '*.py')):
+        shutil.copy(py_file, temp_package_dir)
+
+    # Compile the YARA rules.
+    compile_rules(os.path.join(temp_package_dir, COMPILED_RULES_FILENAME))
+
+    # Extract the AWS-native Python deps into the package.
+    with zipfile.ZipFile(ANALYZE_DEPENDENCIES, 'r') as deps:
+        deps.extractall(temp_package_dir)
+
+    # Zip up the package and remove temporary directory.
+    shutil.make_archive(os.path.join(target_directory, ANALYZE_ZIPFILE), 'zip', temp_package_dir)
+    shutil.rmtree(temp_package_dir)
+
+
+def _build_batcher(target_directory):
+    """Build the batcher Lambda deployment package."""
+    print('Creating batcher deploy package...')
+    with zipfile.ZipFile(os.path.join(target_directory, BATCH_ZIPFILE), 'w') as pkg:
+        pkg.write(BATCH_SOURCE, os.path.basename(BATCH_SOURCE))
+
+
+def _build_dispatcher(target_directory):
+    """Build the dispatcher Lambda deployment package."""
+    print('Creating dispatcher deploy package...')
+    with zipfile.ZipFile(os.path.join(target_directory, DISPATCH_ZIPFILE), 'w') as pkg:
+        pkg.write(DISPATCH_SOURCE, os.path.basename(DISPATCH_SOURCE))
+
+
+def build(target_directory):
+    """Build Lambda deployment packages.
+
+    Args:
+        target_directory: [String] Path to folder which will store generated zipfiles.
+    """
+    _build_analyzer(target_directory)
+    _build_batcher(target_directory)
+    _build_dispatcher(target_directory)

--- a/lambda_functions/build.py
+++ b/lambda_functions/build.py
@@ -12,13 +12,13 @@ LAMBDA_DIR = os.path.dirname(os.path.realpath(__file__))
 
 ANALYZE_SOURCE = os.path.join(LAMBDA_DIR, 'analyzer')
 ANALYZE_DEPENDENCIES = os.path.join(ANALYZE_SOURCE, 'yara_python_3.6.3.zip')
-ANALYZE_ZIPFILE = 'lambda_analyzer'  # ".zip" will be added later
+ANALYZE_ZIPFILE = 'lambda_analyzer'
 
 BATCH_SOURCE = os.path.join(LAMBDA_DIR, 'batcher', 'main.py')
-BATCH_ZIPFILE = 'lambda_batcher.zip'
+BATCH_ZIPFILE = 'lambda_batcher'
 
 DISPATCH_SOURCE = os.path.join(LAMBDA_DIR, 'dispatcher', 'main.py')
-DISPATCH_ZIPFILE = 'lambda_dispatcher.zip'
+DISPATCH_ZIPFILE = 'lambda_dispatcher'
 
 
 def _build_analyzer(target_directory):
@@ -48,14 +48,14 @@ def _build_analyzer(target_directory):
 def _build_batcher(target_directory):
     """Build the batcher Lambda deployment package."""
     print('Creating batcher deploy package...')
-    with zipfile.ZipFile(os.path.join(target_directory, BATCH_ZIPFILE), 'w') as pkg:
+    with zipfile.ZipFile(os.path.join(target_directory, BATCH_ZIPFILE + '.zip'), 'w') as pkg:
         pkg.write(BATCH_SOURCE, os.path.basename(BATCH_SOURCE))
 
 
 def _build_dispatcher(target_directory):
     """Build the dispatcher Lambda deployment package."""
     print('Creating dispatcher deploy package...')
-    with zipfile.ZipFile(os.path.join(target_directory, DISPATCH_ZIPFILE), 'w') as pkg:
+    with zipfile.ZipFile(os.path.join(target_directory, DISPATCH_ZIPFILE + '.zip'), 'w') as pkg:
         pkg.write(DISPATCH_SOURCE, os.path.basename(DISPATCH_SOURCE))
 
 

--- a/manage.py
+++ b/manage.py
@@ -47,7 +47,7 @@ class Manager(object):
 
     @property
     def help(self):
-        """Return help string about each available command (built from docstrings)."""
+        """Return method docstring for each available command."""
         return '\n'.join(
             '{:<15}{}'.format(command, inspect.getdoc(getattr(self, command)))
             for command in sorted(self.commands)

--- a/manage.py
+++ b/manage.py
@@ -1,36 +1,22 @@
 """Command-line tool for easily managing BinaryAlert."""
 # Usage: python3 manage.py [--help] [command]
 import argparse
-import glob
+import inspect
 import os
-import shutil
 import subprocess
 import sys
 import unittest
-import tempfile
-import zipfile
 
 import boto3
 import hcl
 
-from lambda_functions.analyzer.main import COMPILED_RULES_FILENAME
-from rules.compile_rules import compile_rules
+from lambda_functions.build import build as lambda_build
 from rules.update_rules import update_github_rules
 from tests import boto3_mocks
 
 PROJECT_DIR = os.path.dirname(os.path.realpath(__file__))  # Directory containing this file.
 TERRAFORM_DIR = os.path.join(PROJECT_DIR, 'terraform')
 CONFIG_FILE = os.path.join(TERRAFORM_DIR, 'terraform.tfvars')
-
-ANALYZE_LAMBDA_SOURCE = os.path.join(PROJECT_DIR, 'lambda_functions', 'analyzer')
-ANALYZE_LAMBDA_DEPENDENCIES = os.path.join(ANALYZE_LAMBDA_SOURCE, 'yara_python_3.6.3.zip')
-ANALYZE_LAMBDA_PACKAGE = os.path.join(TERRAFORM_DIR, 'lambda_analyzer')  # ".zip" added later.
-
-BATCH_LAMBDA_SOURCE = os.path.join(PROJECT_DIR, 'lambda_functions', 'batcher', 'main.py')
-BATCH_LAMBDA_PACKAGE = os.path.join(TERRAFORM_DIR, 'lambda_batcher.zip')
-
-DISPATCH_LAMBDA_SOURCE = os.path.join(PROJECT_DIR, 'lambda_functions', 'dispatcher', 'main.py')
-DISPATCH_LAMBDA_PACKAGE = os.path.join(TERRAFORM_DIR, 'lambda_dispatcher.zip')
 
 # Lambda alias terraform targets, to be updated separately.
 LAMBDA_ALIASES_TERRAFORM_TARGETS = [
@@ -39,132 +25,109 @@ LAMBDA_ALIASES_TERRAFORM_TARGETS = [
 ]
 
 
-def _parse_config_data():
-    """Parse the BinaryAlert config file and return the configuration as a dict."""
-    print('Reading config file {}...'.format(CONFIG_FILE))
-    with open(CONFIG_FILE) as config_file:
-        return hcl.load(config_file)
+class Manager(object):
+    """BinaryAlert management utility."""
 
+    def __init__(self, config_file):
+        """Parse config and setup boto3.
 
-def update_rules():
-    """Update YARA rules cloned from github.com."""
-    update_github_rules()
+        Args:
+            config_file: [String] path to the terraform.tfvars configuration file.
+        """
+        print('Reading config file {}...'.format(config_file))
+        with open(config_file) as f:
+            self._config = hcl.load(f)
 
+        boto3.setup_default_session(region_name=self._config['aws_region'])
 
-def deploy():
-    """Build the Lambda deployment packages and terraform apply."""
-    test()
-    build()
-    apply()
-    analyze_all()
+    @property
+    def commands(self):
+        """Return set of available commands."""
+        return {'apply', 'analyze_all', 'build', 'deploy', 'update_rules', 'test'}
 
+    @property
+    def help(self):
+        """Return help string about each available command (built from docstrings)."""
+        return '\n'.join(
+            '{:<15}{}'.format(command, inspect.getdoc(getattr(self, command)))
+            for command in sorted(self.commands)
+        )
 
-@boto3_mocks.restore_http_adapter
-def test():
-    """Run all *_test.py unittests and exit 1 if tests failed."""
-    suite = unittest.TestLoader().discover(PROJECT_DIR, pattern='*_test.py')
-    test_result = unittest.TextTestRunner(verbosity=1).run(suite)
-    if not test_result.wasSuccessful():
-        sys.exit("Unit tests failed")  # Exit code 1
+    def run(self, command):
+        """Execute one of the available commands.
 
+        Args:
+            command: [String] Command in self.commands.
+        """
+        getattr(self, command)()  # Validation already happened in the ArgumentParser.
 
-def _build_analyzer():
-    """Build the YARA analyzer Lambda deployment package."""
-    # Create a new copy of the core lambda directory to avoid cluttering the original.
-    temp_package_dir = os.path.join(tempfile.gettempdir(), 'tmp_yara_analyzer.pkg')
-    if os.path.exists(temp_package_dir):
-        shutil.rmtree(temp_package_dir)
-    os.mkdir(temp_package_dir)
-    for py_file in glob.glob(os.path.join(ANALYZE_LAMBDA_SOURCE, '*.py')):
-        shutil.copy(py_file, temp_package_dir)
+    @staticmethod
+    def update_rules():
+        """Update YARA rules cloned from other open-source projects."""
+        update_github_rules()
 
-    # Clone the YARA-rules repo and compile the YARA rules.
-    compile_rules(os.path.join(temp_package_dir, COMPILED_RULES_FILENAME))
+    def deploy(self):
+        """Deploy BinaryAlert. Equivalent to test + build + apply + analyze_all."""
+        self.test()
+        self.build()
+        self.apply()
+        self.analyze_all()
 
-    # Extract the AWS-native Python deps into the package.
-    print('Creating analyzer deploy package...')
-    with zipfile.ZipFile(ANALYZE_LAMBDA_DEPENDENCIES, 'r') as deps:
-        deps.extractall(temp_package_dir)
+    @staticmethod
+    @boto3_mocks.restore_http_adapter
+    def test():
+        """Run unit tests (*_test.py)."""
+        suite = unittest.TestLoader().discover(PROJECT_DIR, pattern='*_test.py')
+        test_result = unittest.TextTestRunner(verbosity=1).run(suite)
+        if not test_result.wasSuccessful():
+            sys.exit('Unit tests failed')  # Exit code 1
 
-    # Zip up the package and remove temporary directory.
-    shutil.make_archive(ANALYZE_LAMBDA_PACKAGE, 'zip', temp_package_dir)
-    shutil.rmtree(temp_package_dir)
+    @staticmethod
+    def build():
+        """Build Lambda packages (saves *.zip files in terraform/)."""
+        lambda_build(TERRAFORM_DIR)
 
+    @staticmethod
+    def apply():
+        """Terraform validate and apply any configuration/package changes."""
+        # Validate and format the terraform files.
+        os.chdir(TERRAFORM_DIR)
+        subprocess.check_call(['terraform', 'validate'])
+        subprocess.check_call(['terraform', 'fmt'])
 
-def _build_batcher():
-    """Build the batcher Lambda deployment package."""
-    print('Creating batcher deploy package...')
-    with zipfile.ZipFile(BATCH_LAMBDA_PACKAGE, 'w') as pkg:
-        pkg.write(BATCH_LAMBDA_SOURCE, os.path.basename(BATCH_LAMBDA_SOURCE))
+        # Setup the backend if needed and reload modules.
+        subprocess.check_call(['terraform', 'init'])
 
+        # Apply changes.
+        subprocess.check_call(['terraform', 'apply'])
 
-def _build_dispatcher():
-    """Build the dispatcher Lambda deployment package."""
-    print('Creating dispatcher deploy package...')
-    with zipfile.ZipFile(DISPATCH_LAMBDA_PACKAGE, 'w') as pkg:
-        pkg.write(DISPATCH_LAMBDA_SOURCE, os.path.basename(DISPATCH_LAMBDA_SOURCE))
+        # A second apply is unfortunately necessary to update the Lambda aliases.
+        print('\nRe-applying to update Lambda aliases...')
+        subprocess.check_call(
+            ['terraform', 'apply', '-refresh=false'] + LAMBDA_ALIASES_TERRAFORM_TARGETS)
 
+    def analyze_all(self):
+        """Start a batcher to asynchronously re-analyze the entire S3 bucket."""
+        function_name = '{}_binaryalert_batcher'.format(self._config['name_prefix'])
 
-def build():
-    """Build Lambda deployment packages."""
-    _build_analyzer()
-    _build_batcher()
-    _build_dispatcher()
-
-
-def apply():
-    """Run terraform apply. Raises an exception if the Terraform is invalid."""
-    # Validate and format the terraform files.
-    os.chdir(TERRAFORM_DIR)
-    subprocess.check_call(['terraform', 'validate'])
-    subprocess.check_call(['terraform', 'fmt'])
-
-    # Setup the backend if needed and reload modules.
-    subprocess.check_call(['terraform', 'init'])
-
-    # Apply changes.
-    subprocess.check_call(['terraform', 'apply'])
-
-    # A second apply is unfortunately necessary to update the Lambda aliases.
-    print('\nRe-applying to update Lambda aliases...')
-    subprocess.check_call(
-        ['terraform', 'apply', '-refresh=false'] + LAMBDA_ALIASES_TERRAFORM_TARGETS)
-
-
-def analyze_all():
-    """Run the batcher to asynchronously re-analyze the entire S3 bucket."""
-    config_data = _parse_config_data()  # TODO: Avoid parsing config data twice
-    function_name = '{}_binaryalert_batcher'.format(config_data['name_prefix'])
-
-    print('Asynchronously invoking {}...'.format(function_name))
-    boto3.client('lambda').invoke(
-        FunctionName=function_name,
-        InvocationType='Event',  # Asynchronous invocation.
-        Qualifier='Production'
-    )
-    print('Batcher invocation successful!')
+        print('Asynchronously invoking {}...'.format(function_name))
+        boto3.client('lambda').invoke(
+            FunctionName=function_name,
+            InvocationType='Event',  # Asynchronous invocation.
+            Qualifier='Production'
+        )
+        print('Batcher invocation successful!')
 
 
 def main():
     """Main command dispatcher."""
+    manager = Manager(CONFIG_FILE)
+
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument(
-        'command',
-        choices=['update_rules', 'deploy', 'test', 'build', 'apply', 'analyze_all'],
-        help='update_rules  Update YARA rules cloned from other open-source projects.\n'
-             'deploy        Deploy BinaryAlert. Equivalent to test + build + apply + analyze_all.\n'
-             'test          Run unit tests (*_test.py).\n'
-             'build         Build Lambda packages (saves *.zip files in terraform/).\n'
-             'apply         Terraform validate and apply any configuration/package changes.\n'
-             'analyze_all   Start a batcher to asynchronously re-analyze the entire S3 bucket.')
+    parser.add_argument('command', choices=sorted(manager.commands), help=manager.help)
     args = parser.parse_args()
 
-    # Set boto3 region.
-    config_data = _parse_config_data()
-    boto3.setup_default_session(region_name=config_data['aws_region'])
-
-    # Dispatch to the appropriate function.
-    globals()[args.command]()
+    manager.run(args.command)
 
 
 if __name__ == '__main__':

--- a/tests/boto3_mocks.py
+++ b/tests/boto3_mocks.py
@@ -18,6 +18,7 @@ def restore_http_adapter(func):
         real_adapter_send = HTTPAdapter.send
         func()
         HTTPAdapter.send = real_adapter_send
+    func_wrapper.__doc__ = func.__doc__  # Replace docstring of inner function with the original.
     return func_wrapper
 
 

--- a/tests/lambda_functions/build_test.py
+++ b/tests/lambda_functions/build_test.py
@@ -1,0 +1,72 @@
+"""Test lambda_functions/build.py."""
+import os
+import tempfile
+import unittest
+from unittest import mock
+import zipfile
+
+from lambda_functions import build
+
+
+@mock.patch.object(build, 'print')
+class BuildTest(unittest.TestCase):
+    """Test top-level build command."""
+    # pylint: disable=protected-access
+
+    def setUp(self):
+        """Find temp directory in which to build packages."""
+        self.maxDiff = None  # pylint: disable=invalid-name
+        self._tempdir = tempfile.gettempdir()
+
+    def _verify_filenames(self, archive_path, expected_filenames):
+        """Verify the set of filenames in the zip archive matches the expected list."""
+        with zipfile.ZipFile(archive_path, 'r') as archive:
+            filenames = set(zip_info.filename for zip_info in archive.filelist)
+        self.assertEqual(expected_filenames, filenames)
+
+    def test_build_analyzer(self, mock_print):
+        """Verify that a valid zipfile is generated for analyzer Lambda function."""
+        build._build_analyzer(self._tempdir)
+        self._verify_filenames(
+            os.path.join(self._tempdir, build.ANALYZE_ZIPFILE + '.zip'),
+            {
+                'yara_python-3.6.3.egg-info/',
+                '__init__.py',
+                'analyzer_aws_lib.py',
+                'binary_info.py',
+                'compiled_yara_rules.bin',
+                'file_hash.py',
+                'libpython3.5m.so.1.0',
+                'main.py',
+                'yara.so',
+                'yara_analyzer.py',
+                'yara_python-3.6.3.egg-info/dependency_links.txt',
+                'yara_python-3.6.3.egg-info/installed-files.txt',
+                'yara_python-3.6.3.egg-info/not-zip-safe',
+                'yara_python-3.6.3.egg-info/PKG-INFO',
+                'yara_python-3.6.3.egg-info/SOURCES.txt',
+                'yara_python-3.6.3.egg-info/top_level.txt'
+            }
+        )
+        mock_print.assert_called_once()
+
+    def test_build_batcher(self, mock_print):
+        """Verify that a valid zipfile is generated for the batcher Lambda function."""
+        build._build_batcher(self._tempdir)
+        self._verify_filenames(
+            os.path.join(self._tempdir, build.BATCH_ZIPFILE + '.zip'), {'main.py'}
+        )
+        mock_print.assert_called_once()
+
+    def test_build_dispatcher(self, mock_print):
+        """Verify that a valid zipfile is generated for the dispatcher Lambda function."""
+        build._build_dispatcher(self._tempdir)
+        self._verify_filenames(
+            os.path.join(self._tempdir, build.DISPATCH_ZIPFILE + '.zip'), {'main.py'}
+        )
+        mock_print.assert_called_once()
+
+    def test_build_all(self, mock_print):
+        """Verify that the top-level build function executes without error."""
+        build.build(self._tempdir)
+        self.assertEqual(3, mock_print.call_count)


### PR DESCRIPTION
Splits out the Lambda building logic into a separate file and restructures `manage.py` as a class. This has a number of benefits:

- Fixes a TODO where the config file was parsed twice 
- Isolating the build logic makes it easier to test (tests have been added) and easier to add new functions (e.g. #29) 
- Adding future commands (e.g. #23 ) will be easier

## Tested:
Unit tests

## Reviewers
to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers 