### PR TITLE
[StreamAlert] Fix dynamic keys to work with StreamAlert

### DIFF
--- a/lambda_functions/analyzer/binary_info.py
+++ b/lambda_functions/analyzer/binary_info.py
@@ -105,11 +105,12 @@ class BinaryInfo(object):
                 'S3Location': self.s3_identifier,
                 'SamplePath': self.observed_path
             },
-            'NumMatchedRules': len(self.yara_matches)
+            'NumMatchedRules': len(self.yara_matches),
+            'MatchedRules': {}
         }
 
         for index, match in enumerate(self.yara_matches, start=1):
-            result['MatchedRule{}'.format(index)] = {
+            result['MatchedRules']['Rule{}'.format(index)] = {
                 # YARA string IDs, e.g. "$string1"
                 'MatchedStrings': list(sorted(set(t[1] for t in match.strings))),
                 'Meta': match.meta,

--- a/tests/lambda_functions/analyzer/main_test.py
+++ b/tests/lambda_functions/analyzer/main_test.py
@@ -117,23 +117,25 @@ class MainTest(fake_filesystem_unittest.TestCase):
                     'SamplePath': MOCK_FILE_METADATA['observed_path']
                 },
                 'NumMatchedRules': 2,
-                'MatchedRule1': {
-                    'MatchedStrings': ['$evil_string'],
-                    'Meta': {
-                        'author': 'Austin Byers',
-                        'description': ('A helpful description about why this rule matches '
-                                        'dastardly evil files.')
+                'MatchedRules': {
+                    'Rule1': {
+                        'MatchedStrings': ['$evil_string'],
+                        'Meta': {
+                            'author': 'Austin Byers',
+                            'description': ('A helpful description about why this rule matches '
+                                            'dastardly evil files.')
+                        },
+                        'RuleFile': 'evil_check.yar',
+                        'RuleName': 'contains_evil',
+                        'RuleTags': ['mock_rule', 'has_meta']
                     },
-                    'RuleFile': 'evil_check.yar',
-                    'RuleName': 'contains_evil',
-                    'RuleTags': ['mock_rule', 'has_meta']
-                },
-                'MatchedRule2': {
-                    'MatchedStrings': [],
-                    'Meta': {},
-                    'RuleFile': 'externals.yar',
-                    'RuleName': 'extension_is_exe',
-                    'RuleTags': ['mock_rule']
+                    'Rule2': {
+                        'MatchedStrings': [],
+                        'Meta': {},
+                        'RuleFile': 'externals.yar',
+                        'RuleName': 'extension_is_exe',
+                        'RuleTags': ['mock_rule']
+                    }
                 }
             }
         }
@@ -186,16 +188,18 @@ class MainTest(fake_filesystem_unittest.TestCase):
                     'SamplePath': ''
                 },
                 'NumMatchedRules': 1,
-                'MatchedRule1': {
-                    'MatchedStrings': ['$evil_string'],
-                    'Meta': {
-                        'author': 'Austin Byers',
-                        'description': ('A helpful description about why this rule matches '
-                                        'dastardly evil files.')
-                    },
-                    'RuleFile': 'evil_check.yar',
-                    'RuleName': 'contains_evil',
-                    'RuleTags': ['mock_rule', 'has_meta']
+                'MatchedRules': {
+                    'Rule1': {
+                        'MatchedStrings': ['$evil_string'],
+                        'Meta': {
+                            'author': 'Austin Byers',
+                            'description': ('A helpful description about why this rule matches '
+                                            'dastardly evil files.')
+                        },
+                        'RuleFile': 'evil_check.yar',
+                        'RuleName': 'contains_evil',
+                        'RuleTags': ['mock_rule', 'has_meta']
+                    }
                 }
             },
             'S3:{}:KEY3'.format(MOCK_S3_BUCKET_NAME): {
@@ -207,12 +211,14 @@ class MainTest(fake_filesystem_unittest.TestCase):
                     'SamplePath': 'win32'
                 },
                 'NumMatchedRules': 1,
-                'MatchedRule1': {
-                    'MatchedStrings': [],
-                    'Meta': {},
-                    'RuleFile': 'externals.yar',
-                    'RuleName': 'filename_contains_win32',
-                    'RuleTags': ['mock_rule']
+                'MatchedRules': {
+                    'Rule1': {
+                        'MatchedStrings': [],
+                        'Meta': {},
+                        'RuleFile': 'externals.yar',
+                        'RuleName': 'filename_contains_win32',
+                        'RuleTags': ['mock_rule']
+                    }
                 }
             }
         }


### PR DESCRIPTION
**What**
Converted current dynamic keys to static top level keys in the following files:
- `binary_info.py` 
- `main_test.py` 

**Why**
- BinaryAlert: Issue https://github.com/airbnb/binaryalert/issues/24 caused the functionality between StreamAlert and BinaryAlert to cease after the format of the output was changed. 
- StreamAlert is currently unable to handle dynamic, top-level keys because due to the open issue found here: https://github.com/airbnb/streamalert/issues/150
- BinaryAlert has been modified to send static top level keys until this issue is resolved in StreamAlert.

**Tests**
Passed Locally