### PR TITLE
Add live_test option to CLI

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,18 +1,24 @@
 """Command-line tool for easily managing BinaryAlert."""
 # Usage: python3 manage.py [--help] [command]
 import argparse
+import hashlib
 import inspect
 import os
+import pprint
 import subprocess
 import sys
+import time
 import unittest
+import uuid
 
 import boto3
+from boto3.dynamodb.conditions import Attr, Key
 import hcl
 
 from lambda_functions.build import build as lambda_build
 from rules.update_rules import update_github_rules
 from tests import boto3_mocks
+from tests.rules.eicar_rule_test import EICAR_STRING
 
 PROJECT_DIR = os.path.dirname(os.path.realpath(__file__))  # Directory containing this file.
 TERRAFORM_DIR = os.path.join(PROJECT_DIR, 'terraform')
@@ -34,7 +40,6 @@ class Manager(object):
         Args:
             config_file: [String] path to the terraform.tfvars configuration file.
         """
-        print('Reading config file {}...'.format(config_file))
         with open(config_file) as f:
             self._config = hcl.load(f)
 
@@ -43,7 +48,7 @@ class Manager(object):
     @property
     def commands(self):
         """Return set of available commands."""
-        return {'apply', 'analyze_all', 'build', 'deploy', 'update_rules', 'test'}
+        return {'apply', 'analyze_all', 'build', 'deploy', 'live_test', 'update_rules', 'test'}
 
     @property
     def help(self):
@@ -60,32 +65,6 @@ class Manager(object):
             command: [String] Command in self.commands.
         """
         getattr(self, command)()  # Validation already happened in the ArgumentParser.
-
-    @staticmethod
-    def update_rules():
-        """Update YARA rules cloned from other open-source projects."""
-        update_github_rules()
-
-    def deploy(self):
-        """Deploy BinaryAlert. Equivalent to test + build + apply + analyze_all."""
-        self.test()
-        self.build()
-        self.apply()
-        self.analyze_all()
-
-    @staticmethod
-    @boto3_mocks.restore_http_adapter
-    def test():
-        """Run unit tests (*_test.py)."""
-        suite = unittest.TestLoader().discover(PROJECT_DIR, pattern='*_test.py')
-        test_result = unittest.TextTestRunner(verbosity=1).run(suite)
-        if not test_result.wasSuccessful():
-            sys.exit('Unit tests failed')  # Exit code 1
-
-    @staticmethod
-    def build():
-        """Build Lambda packages (saves *.zip files in terraform/)."""
-        lambda_build(TERRAFORM_DIR)
 
     @staticmethod
     def apply():
@@ -117,6 +96,85 @@ class Manager(object):
             Qualifier='Production'
         )
         print('Batcher invocation successful!')
+
+    @staticmethod
+    def build():
+        """Build Lambda packages (saves *.zip files in terraform/)."""
+        lambda_build(TERRAFORM_DIR)
+
+    def deploy(self):
+        """Deploy BinaryAlert. Equivalent to test + build + apply + analyze_all."""
+        self.test()
+        self.build()
+        self.apply()
+        self.analyze_all()
+
+    def live_test(self):
+        """Upload an EICAR test file to BinaryAlert which should trigger a YARA match alert."""
+        bucket_name = '{}.binaryalert-binaries.{}'.format(
+            self._config['name_prefix'].replace('_', '.'), self._config['aws_region'])
+        test_filename = 'eicar_test_{}.txt'.format(uuid.uuid4())
+        s3_identifier = 'S3:{}:{}'.format(bucket_name, test_filename)
+
+        print('Uploading {}...'.format(s3_identifier))
+        bucket = boto3.resource('s3').Bucket(bucket_name)
+        bucket.put_object(
+            Body=EICAR_STRING.encode('UTF-8'),
+            Key=test_filename,
+            Metadata={'observed_path': test_filename}
+        )
+
+        print('File uploaded! Waiting for new Dynamo entry to appear...')
+        table_name = '{}_binaryalert_matches'.format(self._config['name_prefix'])
+        table = boto3.resource('dynamodb').Table(table_name)
+        eicar_sha256 = hashlib.sha256(EICAR_STRING.encode('UTF-8')).hexdigest()
+        dynamo_record_found = False
+        lambda_version = 0
+
+        for attempt in range(1, 11):
+            time.sleep(5)
+            print('\t[{}/10] Scanning DynamoDB:{}...'.format(attempt, table_name))
+            items = table.query(
+                Select='ALL_ATTRIBUTES',
+                Limit=1,
+                ConsistentRead=True,
+                ScanIndexForward=False,  # Sort by LambdaVersion descending (e.g. newest first).
+                KeyConditionExpression=Key('SHA256').eq(eicar_sha256),
+                FilterExpression=Attr('S3Objects').contains(s3_identifier)
+            ).get('Items')
+            if items:
+                print('\tSUCCESS: Dynamo entry found!\n')
+                dynamo_record_found = True
+                lambda_version = items[0]['LambdaVersion']
+                pprint.pprint(items[0])
+                break
+            elif attempt == 10:
+                print('\nFAIL: Entry not found')
+
+        print('\nRemoving EICAR test file from S3...')
+        bucket.delete_objects(Delete={'Objects': [{'Key': test_filename}]})
+
+        print('Removing Dynamo EICAR entry...')
+        table.delete_item(Key={'SHA256': eicar_sha256, 'LambdaVersion': lambda_version})
+
+        if dynamo_record_found:
+            print('\nLive test succeeded! Verify the alert was sent to your SNS subscription(s).')
+        else:
+            sys.exit('\nLive test failed!')
+
+    @staticmethod
+    def update_rules():
+        """Update YARA rules cloned from other open-source projects."""
+        update_github_rules()
+
+    @staticmethod
+    @boto3_mocks.restore_http_adapter
+    def test():
+        """Run unit tests (*_test.py)."""
+        suite = unittest.TestLoader().discover(PROJECT_DIR, pattern='*_test.py')
+        test_result = unittest.TextTestRunner(verbosity=1).run(suite)
+        if not test_result.wasSuccessful():
+            sys.exit('Unit tests failed')  # Exit code 1
 
 
 def main():


### PR DESCRIPTION
`python3 manage.py live_test` has been added, which will:

1. Upload an EICAR test file to the BinaryAlert S3 bucket
2. Search for the YARA match information in Dynamo and print it
3. Remove the test file and resulting Dynamo entry regardless of whether the test was successful

Resolves: #23 

This also alphabetizes all of the CLI commands in the `Manager` class

## Example Run
```
(venv)$ python3 manage.py live_test
Uploading EICAR test file S3:[bucket]:eicar_test_0f5fabe7-e515-4666-97b4-ad17fc34eca4.txt...
EICAR test file uploaded! Connecting to table DynamoDB:[table]...
	[1/10] Querying DynamoDB table for the expected YARA match entry...
	[2/10] Querying DynamoDB table for the expected YARA match entry...
	[3/10] Querying DynamoDB table for the expected YARA match entry...
	[4/10] Querying DynamoDB table for the expected YARA match entry...
	[5/10] Querying DynamoDB table for the expected YARA match entry...

SUCCESS: Expected DynamoDB entry for the EICAR file was found!

{'LambdaVersion': Decimal('5'),
 'MD5_Computed': '44d88612fea8a8f36de82e1278abb02f',
 'MatchedRules': {'public/eicar.yara:eicar_av_test'},
 'S3Objects': {'S3:[bucket]:eicar_test_0f5fabe7-e515-4666-97b4-ad17fc34eca4.txt'},
 'SHA256': '275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f',
 'SamplePath': 'eicar_test_0f5fabe7-e515-4666-97b4-ad17fc34eca4.txt'}

Removing EICAR test file from S3...
Removing DynamoDB EICAR entry...

Live test succeeded! Verify the alert was sent to your SNS subscription(s).
```

## Reviewers
to: @jacknagz 
cc: @airbnb/binaryalert-maintainers 