### PR TITLE
Add coveralls and require 85% test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source=.
+omit=venv/*
+
+[report]
+fail_under=85

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 python: "3.6"
-install: "pip3 install -r requirements.txt"
+install:
+  - pip3 install -r requirements.txt
 script:
-  - "python3 manage.py test"
-  - "find . -name '*.py' -exec pylint '{}' +"
+  - coverage run manage.py test
+  - coverage report  # Required coverage threshold specified in .coveragerc
+  - find . -name '*.py' -exec pylint '{}' +
+after_sucess:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # BinaryAlert: Serverless, Real-time & Retroactive Malware Detection
-![BinaryAlert Logo](img/logo.png)
-
 [![Build Status](https://travis-ci.org/airbnb/binaryalert.svg?branch=master)](https://travis-ci.org/airbnb/binaryalert)
 [![Coverage Status](https://coveralls.io/repos/github/airbnb/binaryalert/badge.svg?branch=master)](https://coveralls.io/github/airbnb/binaryalert?branch=master)
+
+
+![BinaryAlert Logo](img/logo.png)
 
 BinaryAlert is an open-source serverless AWS pipeline where any file uploaded to an S3 bucket is
 immediately scanned with a configurable set of [YARA](https://virustotal.github.io/yara/) rules.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # BinaryAlert: Serverless, Real-time & Retroactive Malware Detection
 ![BinaryAlert Logo](img/logo.png)
 
+[![Build Status](https://travis-ci.org/airbnb/binaryalert.svg?branch=master)](https://travis-ci.org/airbnb/binaryalert)
+[![Coverage Status](https://coveralls.io/repos/github/airbnb/binaryalert/badge.svg?branch=master)](https://coveralls.io/github/airbnb/binaryalert?branch=master)
+
 BinaryAlert is an open-source serverless AWS pipeline where any file uploaded to an S3 bucket is
 immediately scanned with a configurable set of [YARA](https://virustotal.github.io/yara/) rules.
 An alert will fire as soon as any match is found, giving an incident response team the ability to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 astroid==1.5.3
 boto==2.48.0
 boto3==1.4.5
-botocore==1.5.92
+botocore==1.5.95
 certifi==2017.7.27.1
 chardet==3.0.4
 cookies==2.2.1
+coverage==4.4.1
 dicttoxml==1.7.4
-docutils==0.13.1
+docutils==0.14
 idna==2.5
 isort==4.2.15
 Jinja2==2.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ certifi==2017.7.27.1
 chardet==3.0.4
 cookies==2.2.1
 coverage==4.4.1
+coveralls==1.1
 dicttoxml==1.7.4
+docopt==0.6.2
 docutils==0.14
 idna==2.5
 isort==4.2.15

--- a/requirements_top_level.txt
+++ b/requirements_top_level.txt
@@ -1,5 +1,6 @@
 boto3
 coverage
+coveralls
 moto
 pyfakefs
 pyhcl

--- a/requirements_top_level.txt
+++ b/requirements_top_level.txt
@@ -1,4 +1,5 @@
 boto3
+coverage
 moto
 pyfakefs
 pyhcl


### PR DESCRIPTION
Add `coverage` instrumentation. Unit tests can now be run with `coverage run manage.py test`
We require 85% coverage for all future PRs for now (that number will increase in the future)

Resolves: #3 

to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers 