### PR TITLE
Clarify Python version and name_prefix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ quickly contain the threat before it spreads.
 
 ## Quick Start
   1. Install dependencies
-      1. Install Python3, pip3, [virtualenv](https://virtualenv.pypa.io/en/stable/), and
+      1. Install Python3.6, pip3, [virtualenv](https://virtualenv.pypa.io/en/stable/), and
       [Terraform](https://www.terraform.io/intro/getting-started/install.html).
       2. Create a virtual environment: `virtualenv -p python3 venv`
       3. Activate the virtual env: `source venv/bin/activate`

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -6,7 +6,7 @@
 // AWS region in which to deploy the BinaryAlert components.
 aws_region = "us-east-1"
 
-// Prefix used in all resource names (required for uniqueness). E.g. "company_team."
+// Prefix used in all resource names (required for uniqueness). E.g. "company_team"
 name_prefix = "" // UNIQUE PREFIX HERE
 
 /* ********** Log Retention ********** */


### PR DESCRIPTION
Clarify that Python3.6 is the precise required version and remove the '.' from the `name_prefix` config example, since periods are not allowed in some resource names