### PR TITLE
Upgrade to Terraform v0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ quickly contain the threat before it spreads.
 ## Quick Start
   1. Install dependencies
       1. Install Python3.6, pip3, [virtualenv](https://virtualenv.pypa.io/en/stable/), and
-      [Terraform](https://www.terraform.io/intro/getting-started/install.html).
+      [Terraform v0.10.1+](https://www.terraform.io/downloads.html).
       2. Create a virtual environment: `virtualenv -p python3 venv`
       3. Activate the virtual env: `source venv/bin/activate`
       4. Install third-party libraries: `pip3 install -r requirements.txt`

--- a/manage.py
+++ b/manage.py
@@ -103,19 +103,22 @@ class Manager(object):
 
         # Validate and format the terraform files.
         os.chdir(TERRAFORM_DIR)
-        subprocess.check_call(['terraform', 'validate'])
+        # TODO: In Terraform 0.10.3, the -var-file flag won't be necessary here
+        subprocess.check_call(['terraform', 'validate', '-var-file', CONFIG_FILE])
         subprocess.check_call(['terraform', 'fmt'])
 
         # Setup the backend if needed and reload modules.
         subprocess.check_call(['terraform', 'init'])
 
-        # Apply changes.
-        subprocess.check_call(['terraform', 'apply'])
+        # Apply changes (requires interactive approval)
+        subprocess.check_call(['terraform', 'apply', '-auto-approve=false'])
 
         # A second apply is unfortunately necessary to update the Lambda aliases.
         print('\nRe-applying to update Lambda aliases...')
         subprocess.check_call(
-            ['terraform', 'apply', '-refresh=false'] + LAMBDA_ALIASES_TERRAFORM_TARGETS)
+            ['terraform', 'apply', '-auto-approve=true', '-refresh=false'] +
+            LAMBDA_ALIASES_TERRAFORM_TARGETS
+        )
 
     def analyze_all(self):
         """Start a batcher to asynchronously re-analyze the entire S3 bucket."""

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,10 @@
-provider "aws" {
-  region = "${var.aws_region}"
+terraform {
+  // 0.10.1 includes important bug fixes for remote backends
+  required_version = "~> 0.10.1"
 }
 
-terraform {
-  required_version = "~> 0.9.6"
+provider "aws" {
+  // 0.1.4 required for aws_cloudwatch_dashboard
+  version = "~> 0.1.4"
+  region  = "${var.aws_region}"
 }


### PR DESCRIPTION
Upgrades to Terraform v0.10! This lets us upgrade to the latest AWS provider and supports interactive approval during each `apply` operation.

No work is required for users to upgrade as long as the latest `terraform` binary is in their PATH.

During a deploy, the user is now required to explicitly approve the changes for the main `apply`. However, the second `apply` (which only updates Lambda aliases) happens automatically, because it shouldn't even be necessary. If the Lambda function updates (and the user approves), then its alias will have to update as well. It would also be annoying for the user to have to explicitly approve twice on every deploy.

Resolves: #32 (Terraform v0.10)
Required for: #6 (Cloudwatch dashboard)

## Tested
Tested with a deploy and `live_test`. A deploy now looks like this:
```
$ python3 manage.py deploy
...
Do you want to apply these changes?
  Terraform will apply the changes described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes
...
```

## Reviewers
to: @jacknagz 
cc: @airbnb/binaryalert-maintainers 
