### PR TITLE
URL-decode S3 keys from the event notification

### DIFF
--- a/lambda_functions/analyzer/main.py
+++ b/lambda_functions/analyzer/main.py
@@ -7,6 +7,7 @@
 # Expects a binary YARA rules file to be at './compiled_yara_rules.bin'
 import logging
 import os
+import urllib
 
 from yara import Error as YaraError
 from botocore.exceptions import ClientError as BotoError
@@ -71,7 +72,9 @@ def analyze_lambda_handler(event_data, lambda_context):
 
     LOGGER.info('Processing %d record(s)', len(event_data['S3Objects']))
     for s3_key in event_data['S3Objects']:
-        LOGGER.info('Analyzing %s', s3_key)
+        # S3 keys in event notifications are url-encoded.
+        s3_key = urllib.parse.unquote_plus(s3_key)
+        LOGGER.info('Analyzing "%s"', s3_key)
 
         with binary_info.BinaryInfo(os.environ['S3_BUCKET_NAME'], s3_key, ANALYZER) as binary:
             result[binary.s3_identifier] = binary.summary()

--- a/tests/lambda_functions/analyzer/main_test.py
+++ b/tests/lambda_functions/analyzer/main_test.py
@@ -4,6 +4,7 @@ import json
 import os
 import unittest
 from unittest import mock
+import urllib
 
 import boto3
 from pyfakefs import fake_filesystem_unittest
@@ -18,7 +19,7 @@ MOCK_FILE_METADATA = {
     'observed_path': '/path/to/mock-evil.exe',
     'reported_md5': 'REPORTED MD5'
 }
-MOCK_S3_OBJECT_KEY = 'random-uuid'
+MOCK_S3_OBJECT_KEY = 'space plus+file.test'
 
 # Mimics minimal parts of S3:ObjectAdded event that triggers the lambda function.
 LAMBDA_VERSION = 1
@@ -77,7 +78,10 @@ class MainTest(fake_filesystem_unittest.TestCase):
         boto3.client = mock.MagicMock(side_effect=self._boto3_client_mock)
 
         # Create test event.
-        self._test_event = {'S3Objects': [MOCK_S3_OBJECT_KEY], 'SQSReceipts': MOCK_SQS_RECEIPTS}
+        self._test_event = {
+            'S3Objects': [urllib.parse.quote_plus(MOCK_S3_OBJECT_KEY)],
+            'SQSReceipts': MOCK_SQS_RECEIPTS
+        }
 
     def tearDown(self):
         """Restore boto3.client to its original."""


### PR DESCRIPTION
A careful look at the [S3 event notification documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html) reveals that the included S3 object key is URL-encoded.

This PR changes the analyzer to URL-decode the S3 key from the notification record before trying to download from S3.

Resolves: #4 

## Tested
Changed the unit tests to url-encode the filenames when invoking the main handler.

Test deploy followed by a manual upload of `space plus+test.txt` was analyzed correctly.

## Reviewers
Size: tiny
to: @jacknagz 
cc: @airbnb/binaryalert-maintainers 