### PR TITLE
gitignore - compiled_yara_rules.bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ lambda_*.zip
 # Virtualenv
 venv/
 
+# Compiled YARA rules
+compiled_yara_rules.bin
+
 # IDE
 .idea/
 


### PR DESCRIPTION
to: @austinbyers 

Ignore `compiled_yara_rules.bin`, which is generated when locally compiling YARA rules.