### PR TITLE
CB event type should be binarystore.file.added

### DIFF
--- a/lambda_functions/downloader/README.md
+++ b/lambda_functions/downloader/README.md
@@ -1,6 +1,6 @@
 # CarbonBlack Binary Downloader
 This optional Lambda function copies a binary from CarbonBlack Enterprise Response into the BinaryAlert S3 bucket for analysis.
-It can invoked every time CarbonBlack logs a `binary.added` event.
+It can invoked every time CarbonBlack logs a `binarystore.file.added` event over the server message bus. 
 
 
 ## One-Time Copy All CarbonBlack Binaries


### PR DESCRIPTION
I believe the correct event type for the notification of a binary being stored successfully on the server is binarystore.file.added

https://github.com/carbonblack/cbapi/tree/master/server_apis#new-binary-file-arrival