### PR TITLE
Add rtd-theme and fix S3 metric in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BinaryAlert: Serverless, Real-time & Retroactive Malware Detection
 [![Build Status](https://travis-ci.org/airbnb/binaryalert.svg?branch=master)](https://travis-ci.org/airbnb/binaryalert)
 [![Coverage Status](https://coveralls.io/repos/github/airbnb/binaryalert/badge.svg?branch=master)](https://coveralls.io/github/airbnb/binaryalert?branch=master)
+[![Documentation Status](https://readthedocs.org/projects/binaryalert/badge/?version=latest)](http://www.binaryalert.io/?badge=latest)
 
 
 ![BinaryAlert Logo](docs/images/logo.png)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,14 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import os
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
 
 # -- General configuration ------------------------------------------------
 
@@ -47,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'BinaryAlert'
-copyright = '2017, Austin Byers'
+copyright = '2017, Airbnb'
 author = 'Austin Byers'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -83,7 +91,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+# html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -101,15 +109,15 @@ html_theme = 'alabaster'
 #
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    '**': [
-        'about.html',
-        'navigation.html',
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
-        'donate.html',
-    ]
-}
+# html_sidebars = {
+#     '**': [
+#         'about.html',
+#         'navigation.html',
+#         'relations.html',  # needs 'show_related': True theme option to display
+#         'searchbox.html',
+#         'donate.html',
+#     ]
+# }
 
 
 # -- Options for HTMLHelp output ------------------------------------------
@@ -167,8 +175,6 @@ texinfo_documents = [
      author, 'BinaryAlert', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
 
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.intersphinx']
+extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -124,58 +124,3 @@ todo_include_todos = False
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'BinaryAlertdoc'
-
-
-# -- Options for LaTeX output ---------------------------------------------
-
-latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
-
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
-
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
-
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
-}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'BinaryAlert.tex', 'BinaryAlert Documentation',
-     'Austin Byers', 'manual'),
-]
-
-
-# -- Options for manual page output ---------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'binaryalert', 'BinaryAlert Documentation',
-     [author], 1)
-]
-
-
-# -- Options for Texinfo output -------------------------------------------
-
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
-texinfo_documents = [
-    (master_doc, 'BinaryAlert', 'BinaryAlert Documentation',
-     author, 'BinaryAlert', 'One line description of project.',
-     'Miscellaneous'),
-]
-
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ s3transfer==0.1.11
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.6.3
+sphinx-rtd-theme==0.2.4
 sphinxcontrib-websupport==1.0.1
 typed-ast==1.0.4
 urllib3==1.22

--- a/requirements_top_level.txt
+++ b/requirements_top_level.txt
@@ -8,4 +8,5 @@ pyfakefs
 pyhcl
 pylint
 sphinx
+sphinx-rtd-theme
 yara-python==3.6.3

--- a/terraform/cloudwatch_dashboard.tf
+++ b/terraform/cloudwatch_dashboard.tf
@@ -16,8 +16,12 @@ locals {
     "period": 86400,
     "view": "singleValue",
     "metrics": [
-      ["AWS/S3", "NumberOfObjects", "BucketName", "${aws_s3_bucket.binaryalert_binaries.id}"],
-      [".", "BucketSizeBytes", ".", "."]
+      [
+        "AWS/S3", "NumberOfObjects",
+        "BucketName", "${aws_s3_bucket.binaryalert_binaries.id}",
+        "StorageType", "AllStorageTypes"
+      ],
+      [".", "BucketSizeBytes", ".", ".", ".", "StandardStorage"]
     ]
   }
 }


### PR DESCRIPTION
This modifies the sphinx doc-building to use the Read-The-Docs theme. Now the `docs/conf.py` is nearly the same as the one in StreamAlert.

This also fixes the S3 metrics in the CloudWatch dashboard to reference the appropriate storage types.

to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers 