### PR TITLE
Add Slack README badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,10 @@ BinaryAlert: Serverless, Real-Time & Retroactive Malware Detection
   :target: http://www.binaryalert.io/?badge=latest
   :alt: Documentation Status
 
+.. image:: https://binaryalert.herokuapp.com/badge.svg
+  :target: http://binaryalert.herokuapp.com
+  :alt: Slack Channel
+
 |
 
 .. image:: docs/images/logo.png


### PR DESCRIPTION
Adds a badge to the README for the slack channel.

This is the last commit before v1.0; I've deployed in a test account and run lots of tests.

to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers  