### PR TITLE
Fix typo and add bzip2-devel to yextend requirements

### DIFF
--- a/lambda_functions/analyzer/README.rst
+++ b/lambda_functions/analyzer/README.rst
@@ -21,8 +21,8 @@ and install ``yara-python`` and ``yextend`` as follows:
 
     # Install requirements
     sudo yum update
-    sudo yum install autconf automake gcc gcc-c++ libarchive-devel libtool libuuid-devel \
-        openssl-devel pcre-devel poppler-utils python36 python36-devel zlib-devel
+    sudo yum install autoconf automake bzip2-devel gcc gcc-c++ libarchive-devel libtool \
+        libuuid-devel openssl-devel pcre-devel poppler-utils python36 python36-devel zlib-devel
     sudo pip install nose
 
     # Install YARA


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/binaryalert-maintainers 
size: tiny

## Background

#79 added `yextend` and instructions for how to build it. However, there is a typo in the README.

## Changes

* Fix `autoconf` typo
* Proactively add `bzip2-devel` to the list of `yum` packages in order to compile the latest version of `yextend`

## Testing

- Compiled `yextend` (both v1.5 and latest master commit) using these install instructions verbatim from a fresh EC2 instance
