### PR TITLE
Shred downloaded files when exiting

### DIFF
--- a/lambda_functions/analyzer/binary_info.py
+++ b/lambda_functions/analyzer/binary_info.py
@@ -74,7 +74,7 @@ class BinaryInfo(object):
     def __exit__(self, exception_type, exception_value, traceback):
         """Shred the downloaded binary and delete it from disk."""
         # Note: This runs even during exception handling (it is the "with" context).
-        subprocess.check_call(['shred', '-u', self.download_path])
+        subprocess.check_call(['shred', '--remove', self.download_path])
 
     @property
     def matched_rule_ids(self) -> Set[str]:

--- a/lambda_functions/analyzer/binary_info.py
+++ b/lambda_functions/analyzer/binary_info.py
@@ -1,5 +1,6 @@
 """Keeps track of all information associated with and computed about a binary."""
 import os
+import subprocess
 import tempfile
 import time
 from typing import Any, Dict, List, Set
@@ -71,13 +72,9 @@ class BinaryInfo(object):
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        """Remove the downloaded binary from local disk."""
-        # In Lambda, "os.remove" does not actually remove the file as expected.
-        # Thus, we first truncate the file to set its size to 0 before removing it.
-        if os.path.isfile(self.download_path):
-            with open(self.download_path, 'wb') as file:
-                file.truncate()
-            os.remove(self.download_path)
+        """Shred the downloaded binary and delete it from disk."""
+        # Note: This runs even during exception handling (it is the "with" context).
+        subprocess.check_call(['shred', '-u', self.download_path])
 
     @property
     def matched_rule_ids(self) -> Set[str]:

--- a/tests/lambda_functions/analyzer/main_test.py
+++ b/tests/lambda_functions/analyzer/main_test.py
@@ -126,8 +126,8 @@ class MainTest(fake_filesystem_unittest.TestCase):
 
             # Verify 2 shred calls
             mock_call.assert_has_calls([
-                mock.call(['shred', '-u', mock.ANY]),
-                mock.call(['shred', '-u', mock.ANY])
+                mock.call(['shred', '--remove', mock.ANY]),
+                mock.call(['shred', '--remove', mock.ANY])
             ])
 
         # Verify return value.

--- a/tests/lambda_functions/analyzer/main_test.py
+++ b/tests/lambda_functions/analyzer/main_test.py
@@ -3,7 +3,6 @@ import hashlib
 import json
 import os
 import subprocess
-import tempfile
 from unittest import mock
 import urllib.parse
 


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers 
size: small

## Background

Since BinaryAlert is designed to run in an enterprise environment, it may be scanning sensitive files. Ideally, we could avoid disk entirely and scan everything in memory, but unfortunately this is not yet possible with `yextend`. Instead, we can do our best to shred the file contents before deleting them.

## Changes

* Use the `shred` utility instead of just truncating files after the analyzer is finished with them.

## Testing

- `./manage.py deploy` and `./manage.py live_test`
