### PR TITLE
Send bucket name in analyzer event

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,7 +42,7 @@ Table of Contents
    architecture
    adding-yara-rules
    deploying
-   uploading-files
+   analyzing-files
    yara-matches
    metrics-and-monitoring
    troubleshooting-faq

--- a/lambda_functions/analyzer/yara_analyzer.py
+++ b/lambda_functions/analyzer/yara_analyzer.py
@@ -29,7 +29,7 @@ _YEXTEND_RESULT_KEYS = {
 
 def _convert_yextend_to_yara_match(yextend_json: Dict[str, Any]) -> List[YaraMatch]:
     """Convert Yextend archive analysis results (JSON) into a list of YaraMatch tuples."""
-    if not yextend_json['yara_matches_found']:
+    if not yextend_json.get('yara_matches_found'):
         return []
 
     matches = []

--- a/lambda_functions/batcher/main.py
+++ b/lambda_functions/batcher/main.py
@@ -52,7 +52,15 @@ class SQSMessage(object):
         return {
             'Id': str(self._id),
             'MessageBody': json.dumps({
-                'Records': [{'s3': {'object': {'key': key}}} for key in self._keys]
+                'Records': [
+                    {
+                        's3': {
+                            'bucket': {'name': os.environ['S3_BUCKET_NAME']},
+                            'object': {'key': key}
+                        }
+                    }
+                    for key in self._keys
+                ]
             })
         }
 

--- a/lambda_functions/build.py
+++ b/lambda_functions/build.py
@@ -1,6 +1,7 @@
 """Builds the deployment packages for all of the Lambda functions."""
 import glob
 import os
+import pathlib
 import shutil
 import stat
 import tempfile
@@ -31,6 +32,7 @@ DOWNLOAD_ZIPFILE = 'lambda_downloader'
 def _build_analyzer(target_directory):
     """Build the YARA analyzer Lambda deployment package."""
     print('Creating analyzer deploy package...')
+    pathlib.Path(os.path.join(ANALYZE_SOURCE, 'main.py')).touch()
 
     # Create a new copy of the core lambda directory to avoid cluttering the original.
     temp_package_dir = os.path.join(tempfile.gettempdir(), 'tmp_yara_analyzer.pkg')
@@ -59,6 +61,7 @@ def _build_analyzer(target_directory):
 def _build_batcher(target_directory):
     """Build the batcher Lambda deployment package."""
     print('Creating batcher deploy package...')
+    pathlib.Path(BATCH_SOURCE).touch()  # Change last modified time to force new Lambda deploy
     with zipfile.ZipFile(os.path.join(target_directory, BATCH_ZIPFILE + '.zip'), 'w') as pkg:
         pkg.write(BATCH_SOURCE, os.path.basename(BATCH_SOURCE))
 
@@ -66,6 +69,7 @@ def _build_batcher(target_directory):
 def _build_dispatcher(target_directory):
     """Build the dispatcher Lambda deployment package."""
     print('Creating dispatcher deploy package...')
+    pathlib.Path(DISPATCH_SOURCE).touch()
     with zipfile.ZipFile(os.path.join(target_directory, DISPATCH_ZIPFILE + '.zip'), 'w') as pkg:
         pkg.write(DISPATCH_SOURCE, os.path.basename(DISPATCH_SOURCE))
 
@@ -73,6 +77,8 @@ def _build_dispatcher(target_directory):
 def _build_downloader(target_directory):
     """Build the downloader Lambda deployment package."""
     print('Creating downloader deploy package...')
+    pathlib.Path(DOWNLOAD_SOURCE).touch()
+
     temp_package_dir = os.path.join(tempfile.gettempdir(), 'tmp_yara_downloader.pkg')
     if os.path.exists(temp_package_dir):
         shutil.rmtree(temp_package_dir)

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -98,7 +98,6 @@ module "binaryalert_analyzer" {
   filename        = "lambda_analyzer.zip"
 
   environment_variables = {
-    S3_BUCKET_NAME                 = "${aws_s3_bucket.binaryalert_binaries.id}"
     SQS_QUEUE_URL                  = "${aws_sqs_queue.s3_object_queue.id}"
     YARA_MATCHES_DYNAMO_TABLE_NAME = "${aws_dynamodb_table.binaryalert_yara_matches.name}"
     YARA_ALERTS_SNS_TOPIC_ARN      = "${aws_sns_topic.yara_match_alerts.arn}"

--- a/tests/lambda_functions/batcher/main_test.py
+++ b/tests/lambda_functions/batcher/main_test.py
@@ -10,6 +10,7 @@ import boto3
 from tests import common
 
 
+# TODO: mock.patch
 class MainTest(unittest.TestCase):
     """Test the batcher enqueuing everything from S3 into SQS."""
 
@@ -65,7 +66,12 @@ class MainTest(unittest.TestCase):
                     'Id': '0',
                     'MessageBody': json.dumps({
                         'Records': [
-                            {'s3': {'object': {'key': 'test-key-1'}}}
+                            {
+                                's3': {
+                                    'bucket': {'name': 'test_s3_bucket'},
+                                    'object': {'key': 'test-key-1'}
+                                }
+                            }
                         ]
                     })
                 }
@@ -103,8 +109,18 @@ class MainTest(unittest.TestCase):
                     'Id': '0',
                     'MessageBody': json.dumps({
                         'Records': [
-                            {'s3': {'object': {'key': 'test-key-1'}}},
-                            {'s3': {'object': {'key': 'test-key-2'}}}
+                            {
+                                's3': {
+                                    'bucket': {'name': 'test_s3_bucket'},
+                                    'object': {'key': 'test-key-1'}
+                                }
+                            },
+                            {
+                                's3': {
+                                    'bucket': {'name': 'test_s3_bucket'},
+                                    'object': {'key': 'test-key-2'}
+                                }
+                            }
                         ]
                     })
                 }
@@ -154,8 +170,18 @@ class MainTest(unittest.TestCase):
                     'Id': '0',
                     'MessageBody': json.dumps({
                         'Records': [
-                            {'s3': {'object': {'key': 'test-key-1'}}},
-                            {'s3': {'object': {'key': 'test-key-2'}}}
+                            {
+                                's3': {
+                                    'bucket': {'name': 'test_s3_bucket'},
+                                    'object': {'key': 'test-key-1'}
+                                }
+                            },
+                            {
+                                's3': {
+                                    'bucket': {'name': 'test_s3_bucket'},
+                                    'object': {'key': 'test-key-2'}
+                                }
+                            }
                         ]
                     })
                 },
@@ -163,7 +189,12 @@ class MainTest(unittest.TestCase):
                     'Id': '1',
                     'MessageBody': json.dumps({
                         'Records': [
-                            {'s3': {'object': {'key': 'test-key-3'}}}
+                            {
+                                's3': {
+                                    'bucket': {'name': 'test_s3_bucket'},
+                                    'object': {'key': 'test-key-3'}
+                                }
+                            }
                         ]
                     })
                 }
@@ -219,7 +250,12 @@ class MainTest(unittest.TestCase):
                     'Id': '0',
                     'MessageBody': json.dumps({
                         'Records': [
-                            {'s3': {'object': {'key': 'test-continuation-token'}}}
+                            {
+                                's3': {
+                                    'bucket': {'name': 'test_s3_bucket'},
+                                    'object': {'key': 'test-continuation-token'}
+                                }
+                            }
                         ]
                     })
                 }

--- a/tests/lambda_functions/batcher/main_test.py
+++ b/tests/lambda_functions/batcher/main_test.py
@@ -10,18 +10,18 @@ import boto3
 from tests import common
 
 
-# TODO: mock.patch
+@mock.patch.dict(os.environ, {
+    'BATCH_LAMBDA_NAME': 'test_batch_lambda_name',
+    'BATCH_LAMBDA_QUALIFIER': 'Production',
+    'OBJECTS_PER_MESSAGE': '2',
+    'S3_BUCKET_NAME': 'test_s3_bucket',
+    'SQS_QUEUE_URL': 'test_queue'
+})
 class MainTest(unittest.TestCase):
     """Test the batcher enqueuing everything from S3 into SQS."""
 
     def setUp(self):
         """Set environment variables and setup the mocks."""
-        os.environ['BATCH_LAMBDA_NAME'] = 'test_batch_lambda_name'
-        os.environ['BATCH_LAMBDA_QUALIFIER'] = 'Production'
-        os.environ['OBJECTS_PER_MESSAGE'] = '2'
-        os.environ['S3_BUCKET_NAME'] = 'test_s3_bucket'
-        os.environ['SQS_QUEUE_URL'] = 'test_queue'
-
         with mock.patch.object(boto3, 'client'), mock.patch.object(boto3, 'resource'):
             from lambda_functions.batcher import main
             self.batcher_main = main


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/binaryalert-maintainers 
size: medium
resolves: #70 
resolves: #72

## Changes

* All `main.py` files are touched during a deploy to guarantee that every Lambda function is always updated (#70)
* The analyzer now reads the S3 bucket name from the event instead of from an environment variable, which allows it to scan other existing buckets
* The dispatcher and batcher are updated to use the new record format
* Adds documentation which explains how to use BinaryAlert to scan existing buckets

## Testing

- CI: unit tests, linting, etc
- Deployed to test account, live test, and batch analysis of 10 files
