### PR TITLE
Add a destroy command to the CLI

### DIFF
--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -50,15 +50,20 @@ We recommend using the ``manage.py`` wrapper script for most BinaryAlert managem
   $ terraform show  # Print the current state of the infrastructure
 
 
-.. _terraform_destroy:
+.. _teardown:
 
-Terraform Destroy
-.................
+Teardown
+--------
 To teardown all of the BinaryAlert infrastructure:
 
 .. code-block:: bash
 
-  $ cd terraform/
-  $ terraform destroy
+  $ ./manage.py destroy
 
-.. note:: By default, S3 objects will not be deleted by ``terraform destroy``. To do so, you must first enable the ``force_destroy`` option in the ``terraform/terraform.tfvars`` configuration file and ``apply`` the change.
+By default, the BinaryAlert S3 buckets can't be deleted until they are empty. You will be asked
+if you want to override this setting and delete all objects as well. If so, the new setting will
+be applied before building the destroy plan.
+
+.. note:: You can set ``force_destroy = true`` in the ``terraform/terraform.tfvars`` config file and ``apply`` the change if you want to manually disable S3 delete protections.
+
+Terraform will build a destroy plan which you must approve before the delete will proceed.

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -3,6 +3,8 @@ Getting Started
 All you need is an AWS account to get BinaryAlert up and running in just a few minutes!
 
 
+.. _dependencies:
+
 Install Dependencies
 --------------------
 BinaryAlert can be deployed from any MacOS/Linux environment (and likely Windows as well, though we haven't tried).

--- a/docs/source/troubleshooting-faq.rst
+++ b/docs/source/troubleshooting-faq.rst
@@ -12,6 +12,13 @@ What's the filesize limit?
 The limiting factor is the `space Lambda allocates for "/tmp" <http://docs.aws.amazon.com/lambda/latest/dg/limits.html#limits-list>`_, i.e. **512 MB**. If you use the :ref:`downloader <cb_downloader>`, note that CarbonBlack automatically truncates files to 25 MB.
 
 
+YARA rules with "hash" or "imphash" fail to compile
+---------------------------------------------------
+If the openssl development libraries aren't on your system when installing YARA, the ``hash`` module
+won't work (`example <https://github.com/airbnb/binaryalert/issues/74>`_).
+Be sure to follow instructions for :ref:`Installing Dependencies <dependencies>`.
+
+
 How much does BinaryAlert cost?
 -------------------------------
 The two biggest costs are the S3 storage and Lambda invocations, so it will depend on how many files you have and how often you re-analyze all of them. A rough estimate at current rates is `$0.057 / GB / month <https://medium.com/@austinbyers/good-question-693200ef5830>`_.
@@ -44,7 +51,8 @@ The CarbonBlack server can sometimes take several minutes before binaries and th
 
 Terraform destroy fails because "bucket is not empty"
 -----------------------------------------------------
-The ``force_destroy`` configuration option must be applied before destroying; see the :ref:`terraform destroy <terraform_destroy>` documentation.
+By default, BinaryAlert S3 buckets can't be deleted until they are empty. ``./manage.py destroy``
+will ask if you want to override this setting. See the :ref:`teardown <teardown>` documentation.
 
 
 Contact Us

--- a/manage.py
+++ b/manage.py
@@ -440,7 +440,6 @@ class Manager(object):
                 sys.exit('Please answer exactly "yes" or "no"')
 
             if result == 'yes':
-                # Enable force_destroy for the BinaryAlert S3 buckets
                 print('Enabling force_destroy on the BinaryAlert S3 buckets...')
                 subprocess.check_call([
                     'terraform', 'apply', '-auto-approve=true', '-refresh=false',

--- a/manage.py
+++ b/manage.py
@@ -40,6 +40,8 @@ LAMBDA_ALIASES_TERRAFORM_IDS = [
     'module.binaryalert_{}.aws_lambda_alias.production_alias'.format(name)
     for name in ['analyzer', 'batcher', 'dispatcher', 'downloader']
 ]
+BINARY_BUCKET_TERRAFORM_ID = 'aws_s3_bucket.binaryalert_binaries'
+LOG_BUCKET_TERRAFORM_ID = 'aws_s3_bucket.binaryalert_log_bucket'
 
 CB_KEY_ALIAS_NAME_TEMPLATE = 'alias/{}_binaryalert_carbonblack_credentials'
 
@@ -57,6 +59,15 @@ class InvalidConfigError(ManagerError):
 class TestFailureError(ManagerError):
     """Exception raised when a BinaryAlert test fails."""
     pass
+
+
+def _get_input(prompt: str, default_value: str) -> str:
+    """Wrapper around input() which shows the current (default value)."""
+    if default_value:
+        prompt = '{} ({}): '.format(prompt, default_value)
+    else:
+        prompt = '{}: '.format(prompt)
+    return input(prompt).strip().lower() or default_value
 
 
 class BinaryAlertConfig(object):
@@ -153,6 +164,10 @@ class BinaryAlertConfig(object):
         self._config['encrypted_carbon_black_api_token'] = value
 
     @property
+    def force_destroy(self) -> str:
+        return self._config['force_destroy']
+
+    @property
     def binaryalert_batcher_name(self) -> str:
         return '{}_binaryalert_batcher'.format(self.name_prefix)
 
@@ -161,15 +176,6 @@ class BinaryAlertConfig(object):
         return '{}.binaryalert-binaries.{}'.format(
             self.name_prefix.replace('_', '.'), self.aws_region
         )
-
-    @staticmethod
-    def _get_input(prompt: str, default_value: str) -> str:
-        """Wrapper around input() which shows the current (default value)."""
-        if default_value:
-            prompt = '{} ({}): '.format(prompt, default_value)
-        else:
-            prompt = '{}: '.format(prompt)
-        return input(prompt).strip().lower() or default_value
 
     def _encrypt_cb_api_token(self) -> None:
         """Save an encrypted CarbonBlack API token.
@@ -210,14 +216,14 @@ class BinaryAlertConfig(object):
         """
         while True:  # Get AWS region.
             try:
-                self.aws_region = self._get_input('AWS Region', self.aws_region)
+                self.aws_region = _get_input('AWS Region', self.aws_region)
                 break
             except InvalidConfigError as error:
                 print('ERROR: {}'.format(error))
 
         while True:  # Get name prefix.
             try:
-                self.name_prefix = self._get_input(
+                self.name_prefix = _get_input(
                     'Unique name prefix, e.g. "company_team"', self.name_prefix
                 )
                 break
@@ -225,7 +231,7 @@ class BinaryAlertConfig(object):
                 print('ERROR: {}'.format(error))
 
         while True:  # Enable downloader?
-            enable_downloader = self._get_input(
+            enable_downloader = _get_input(
                 'Enable the CarbonBlack downloader?',
                 'yes' if self.enable_carbon_black_downloader else 'no'
             )
@@ -238,9 +244,7 @@ class BinaryAlertConfig(object):
         if self.enable_carbon_black_downloader:
             while True:  # CarbonBlack URL
                 try:
-                    self.carbon_black_url = self._get_input(
-                        'CarbonBlack URL', self.carbon_black_url
-                    )
+                    self.carbon_black_url = _get_input('CarbonBlack URL', self.carbon_black_url)
                     break
                 except InvalidConfigError as error:
                     print('ERROR: {}'.format(error))
@@ -249,9 +253,7 @@ class BinaryAlertConfig(object):
             if self.encrypted_carbon_black_api_token:
                 # API token already exists - ask if they want to update it.
                 while True:
-                    update_api_token = self._get_input(
-                        'Change the CarbonBlack API token?', 'no'
-                    )
+                    update_api_token = _get_input('Change the CarbonBlack API token?', 'no')
                     if update_api_token in {'yes', 'no'}:
                         break
                     else:
@@ -320,7 +322,7 @@ class Manager(object):
     def commands(self) -> Set[str]:
         """Return set of available management commands."""
         return {'analyze_all', 'apply', 'build', 'cb_copy_all', 'clone_rules', 'compile_rules',
-                'configure', 'deploy', 'live_test', 'unit_test'}
+                'configure', 'deploy', 'destroy', 'live_test', 'unit_test'}
 
     @property
     def help(self) -> str:
@@ -426,6 +428,27 @@ class Manager(object):
         self.build()
         self.apply()
         self.analyze_all()
+
+    def destroy(self) -> None:
+        """Teardown all of the BinaryAlert infrastructure."""
+        os.chdir(TERRAFORM_DIR)
+
+        if not self._config.force_destroy:
+            result = _get_input('Delete all S3 objects as well?', 'no')
+
+            if result not in {'yes', 'no'}:
+                sys.exit('Please answer exactly "yes" or "no"')
+
+            if result == 'yes':
+                # Enable force_destroy for the BinaryAlert S3 buckets
+                print('Enabling force_destroy on the BinaryAlert S3 buckets...')
+                subprocess.check_call([
+                    'terraform', 'apply', '-auto-approve=true', '-refresh=false',
+                    '-var', 'force_destroy=true',
+                    '-target', BINARY_BUCKET_TERRAFORM_ID, '-target', LOG_BUCKET_TERRAFORM_ID
+                ])
+
+        subprocess.call(['terraform', 'destroy'])
 
     def live_test(self) -> None:
         """Upload an EICAR test file to BinaryAlert which should trigger a YARA match alert.

--- a/tests/manage_test.py
+++ b/tests/manage_test.py
@@ -29,6 +29,8 @@ def _mock_input(prompt: str) -> str:
         return 'https://new-example.com'
     elif prompt.startswith('Change the CarbonBlack API token'):
         return 'yes'
+    elif prompt.startswith('Delete all S3 objects'):
+        return 'yes'
     return 'UNKNOWN'
 
 
@@ -358,6 +360,19 @@ class ManagerTest(FakeFilesystemBase):
         mock_build.assert_called_once()
         mock_apply.assert_called_once()
         mock_analyze.assert_called_once()
+
+    @mock.patch.object(manage, 'input', side_effect=_mock_input)
+    @mock.patch.object(manage, 'print')
+    @mock.patch.object(subprocess, 'call')
+    @mock.patch.object(subprocess, 'check_call')
+    def test_destroy(self, mock_check_call: mock.MagicMock, mock_call: mock.MagicMock,
+                     mock_print: mock.MagicMock, mock_input: mock.MagicMock):
+        """Destroy asks whether S3 objects should also be deleted."""
+        self.manager.destroy()
+        mock_input.assert_called_once()
+        mock_print.assert_called_once()
+        mock_check_call.assert_called_once()
+        mock_call.assert_called_once()
 
     @mock.patch.object(time, 'sleep', mock.MagicMock())
     @mock.patch.object(boto3, 'resource')

--- a/tests/manage_test.py
+++ b/tests/manage_test.py
@@ -19,6 +19,7 @@ from tests.rules.eicar_rule_test import EICAR_STRING
 
 def _mock_input(prompt: str) -> str:
     """Mock for the user input() function to automatically respond with valid answers."""
+    # pylint: disable=too-many-return-statements
     if prompt.startswith('AWS Region'):
         return 'us-west-2'
     elif prompt.startswith('Unique name prefix'):


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers 
size: small
resolves: #78 

## Background

BinaryAlert deployments with non-empty S3 buckets can't be destroyed by default. This is by design, to protect against accidental data deletion. However, the current process is somewhat cumbersome: you have to manually `terraform apply` a change to `force_destroy = true`.

There was a request for a `manage.py destroy` option, which I am happy to add

## Changes

* Adds `manage.py destroy` option. If `force_destroy = false` (the default), the user will be prompted whether they want to delete S3 objects as well.
* Updates documentation about the destroy
* Adds a FAQ for the YARA hash issue (see #74 )

## Testing
Several live deploys and destroys, ensuring that S3 buckets are either deleted or not (depending on input).

