### PR TITLE
Update README.rst with perm fix for Lambda 3rd party

### DIFF
--- a/lambda_functions/analyzer/README.rst
+++ b/lambda_functions/analyzer/README.rst
@@ -69,6 +69,7 @@ and install ``yara-python`` and ``yextend`` as follows:
     cp /usr/lib64/libstdc++.so.6 lambda
     cp /usr/local/lib/libyara.so.3 lambda
     cd lambda
+    chmod -R 777 *
     zip -r yara3.7.0_yextend1.6.zip *
 
 


### PR DESCRIPTION
Give Lambda permission to run the 3rd party libs by chmod before zipping

to: @airbnb/binaryalert-maintainers
cc: <optional-cc-to-specific-users>
size: small|medium|large
resolves #<related-issue-goes-here>

## Background

If you're not using the prebuilt lib, and follow the readme without fixing the perms, Lambda will give you this error: "lambda [Errno 13] Permission denied: PermissionError"

## Changes

N/A

## Testing

N/A