### PR TITLE
Update version number in getting started

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -70,7 +70,7 @@ Download BinaryAlert
 
 .. code-block:: bash
 
-  $ git clone --branch v1.0.0 --depth 1 https://github.com/airbnb/binaryalert
+  $ git clone --branch v1.1.0 --depth 1 https://github.com/airbnb/binaryalert
 
 2. Create and activate a virtual environment:
 


### PR DESCRIPTION
to: @jacknagz 
cc: @airbnb/binaryalert-maintainers 
size: tiny

#93 was meant to be the release PR, but I forgot to update the version in the Getting Started documentation.

In the future, we should probably find a way to automatically build this number from the configuration
