### PR TITLE
Add SQS tag and make tag Name variable

### DIFF
--- a/terraform/dynamo.tf
+++ b/terraform/dynamo.tf
@@ -18,6 +18,6 @@ resource "aws_dynamodb_table" "binaryalert_yara_matches" {
   }
 
   tags {
-    Name = "BinaryAlert"
+    Name = "${var.tagged_name}"
   }
 }

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -6,7 +6,7 @@ resource "aws_kms_key" "carbon_black_credentials" {
   enable_key_rotation = true
 
   tags {
-    Name = "BinaryAlert"
+    Name = "${var.tagged_name}"
   }
 }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -18,6 +18,7 @@ module "binaryalert_downloader" {
   }
 
   log_retention_days = "${var.lambda_log_retention_days}"
+  tagged_name        = "${var.tagged_name}"
 
   alarm_errors_help = <<EOF
 The downloader often times out while waiting for CarbonBlack to process the binary.
@@ -51,6 +52,7 @@ module "binaryalert_batcher" {
   }
 
   log_retention_days = "${var.lambda_log_retention_days}"
+  tagged_name        = "${var.tagged_name}"
   alarm_sns_arns     = ["${aws_sns_topic.metric_alarms.arn}"]
 }
 
@@ -73,6 +75,7 @@ module "binaryalert_dispatcher" {
   }
 
   log_retention_days = "${var.lambda_log_retention_days}"
+  tagged_name        = "${var.tagged_name}"
   alarm_sns_arns     = ["${aws_sns_topic.metric_alarms.arn}"]
 }
 
@@ -104,6 +107,7 @@ module "binaryalert_analyzer" {
   }
 
   log_retention_days = "${var.lambda_log_retention_days}"
+  tagged_name        = "${var.tagged_name}"
 
   // During batch operations, the analyzer will have a high error rate because of S3 latency.
   alarm_errors_help = <<EOF

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -35,7 +35,7 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
   retention_in_days = "${var.log_retention_days}"
 
   tags {
-    Name = "BinaryAlert"
+    Name = "${var.tagged_name}"
   }
 }
 
@@ -61,7 +61,7 @@ resource "aws_lambda_function" "function" {
   }
 
   tags {
-    Name = "BinaryAlert"
+    Name = "${var.tagged_name}"
   }
 }
 

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -45,6 +45,10 @@ variable "log_retention_days" {
   description = "Number of days to retain Lambda execution logs in CloudWatch"
 }
 
+variable "tagged_name" {
+  description = "The 'Name' tag on CloudWatch logs and Lambda will be set to this value"
+}
+
 variable "alarm_errors_help" {
   description = "Function-specific context for the error alarm description"
   default     = ""

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket" "binaryalert_log_bucket" {
   }
 
   tags {
-    Name = "BinaryAlert"
+    Name = "${var.tagged_name}"
   }
 
   // Enabling versioning protects against accidental deletes.
@@ -78,7 +78,7 @@ resource "aws_s3_bucket" "binaryalert_binaries" {
   }
 
   tags {
-    Name = "BinaryAlert"
+    Name = "${var.tagged_name}"
   }
 
   versioning {

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -7,6 +7,10 @@ resource "aws_sqs_queue" "s3_object_queue" {
   visibility_timeout_seconds = "${format("%d", var.lambda_analyze_timeout_sec + 2)}"
 
   message_retention_seconds = "${format("%d", var.sqs_retention_minutes * 60)}"
+
+  tags {
+    Name = "${var.tagged_name}"
+  }
 }
 
 data "aws_iam_policy_document" "s3_object_queue_policy" {

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -92,3 +92,8 @@ expected_analysis_frequency_minutes = 30
 // Since there will likely be very few matches, these numbers can be quite low.
 dynamo_read_capacity = 10
 dynamo_write_capacity = 5
+
+// Tags make it easier to organize resources, view grouped billing information, etc.
+// All supported resources (CloudWatch logs, Dyanmo, KMS, Lambda, S3, SQS) are tagged with
+// Name = [YOUR_VALUE_BELOW]
+tagged_name = "BinaryAlert"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,3 +27,4 @@ variable "lambda_download_timeout_sec" {}
 variable "expected_analysis_frequency_minutes" {}
 variable "dynamo_read_capacity" {}
 variable "dynamo_write_capacity" {}
+variable "tagged_name" {}


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers 
size: small

## Background

AWS [added support for SQS tagging](https://aws.amazon.com/blogs/aws/introducing-cost-allocation-tags-for-amazon-sqs/) a few months ago. Tags make it easier to organize AWS resources, view grouped billing information, etc.

## Changes

* Add the "Name = BinaryAlert" tag to SQS, as it is already present on all other supported resources
* The value of the "Name" tag is now a Terraform variable (to make it configurable, e.g. for multiple BinaryAlert deployments within the same account)

Unfortunately, because `tags` is a block for Terraform resources, I don't think there's any easy way to make the entire tag map a variable (I tried).

## Testing
* Terraform validate

  
  