### PR TITLE
Upgrade AWS provider and remove now-redundant second apply

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -32,10 +32,6 @@ TEST_FILES = os.path.join(PROJECT_DIR, 'tests', 'files')
 
 # Terraform identifiers.
 CB_KMS_ALIAS_TERRAFORM_ID = 'aws_kms_alias.encrypt_credentials_alias'
-LAMBDA_ALIASES_TERRAFORM_IDS = [
-    'module.binaryalert_{}.aws_lambda_alias.production_alias'.format(name)
-    for name in ['analyzer', 'batcher', 'dispatcher', 'downloader']
-]
 BINARY_BUCKET_TERRAFORM_ID = 'aws_s3_bucket.binaryalert_binaries'
 LOG_BUCKET_TERRAFORM_ID = 'aws_s3_bucket.binaryalert_log_bucket'
 
@@ -375,18 +371,10 @@ class Manager(object):
         # Setup the backend if needed and reload modules.
         subprocess.check_call(['terraform', 'init'])
 
-        subprocess.check_call(['terraform', 'validate'])
         subprocess.check_call(['terraform', 'fmt'])
 
         # Apply changes (requires interactive approval)
         subprocess.check_call(['terraform', 'apply', '-auto-approve=false'])
-
-        # A second apply is unfortunately necessary to update the Lambda aliases.
-        print('\nRe-applying to update Lambda aliases...')
-        subprocess.check_call(
-            ['terraform', 'apply', '-auto-approve=true', '-refresh=false'] +
-            ['-target=' + alias for alias in LAMBDA_ALIASES_TERRAFORM_IDS]
-        )
 
     def build(self) -> None:
         """Build Lambda packages (saves *.zip files in terraform/)."""

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,6 +3,6 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.5.0"
+  version = "~> 1.11.0"
   region  = "${var.aws_region}"
 }

--- a/tests/manage_test.py
+++ b/tests/manage_test.py
@@ -288,25 +288,15 @@ class ManagerTest(FakeFilesystemBase):
             )
         ])
 
-    @mock.patch.object(manage, 'print')
     @mock.patch.object(subprocess, 'check_call')
-    def test_apply(self, mock_subprocess: mock.MagicMock, mock_print: mock.MagicMock):
+    def test_apply(self, mock_subprocess: mock.MagicMock):
         """Validate order of Terraform operations."""
         self.manager.apply()
         mock_subprocess.assert_has_calls([
             mock.call(['terraform', 'init']),
-            mock.call(['terraform', 'validate']),
             mock.call(['terraform', 'fmt']),
-            mock.call(['terraform', 'apply', '-auto-approve=false']),
-            mock.call([
-                'terraform', 'apply', '-auto-approve=true', '-refresh=false',
-                '-target=module.binaryalert_analyzer.aws_lambda_alias.production_alias',
-                '-target=module.binaryalert_batcher.aws_lambda_alias.production_alias',
-                '-target=module.binaryalert_dispatcher.aws_lambda_alias.production_alias',
-                '-target=module.binaryalert_downloader.aws_lambda_alias.production_alias'
-            ])
+            mock.call(['terraform', 'apply', '-auto-approve=false'])
         ])
-        mock_print.assert_called_once()
 
     @mock.patch.object(manage, 'lambda_build')
     def test_build(self, mock_build: mock.MagicMock):


### PR DESCRIPTION
to: @javuto 
cc: @airbnb/binaryalert-maintainers
size: small

## Background

As of [AWS provider v1.10](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#1100-february-24-2018), Lambda functions with auto-publish correctly recompute the function versions, obviating the need for our second `terraform apply` during a deploy

## Changes

* Upgrade AWS provider minimum version to v.11.0 (the latest release)
* Remove second `terraform apply` (a single one works now)
* Remove `terraform validate` - validation automatically happens during `apply`

## Testing

* Unit tests verify functionality of CLI
* We have other Lambda projects with the new AWS provider which deploy as expected
