### PR TITLE
Remove references to Twitter account which no longer exists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,5 +36,4 @@ Links
 
 - `Announcement Post <https://medium.com/airbnb-engineering/binaryalert-real-time-serverless-malware-detection-ca44370c1b90>`_
 - `Documentation <https://binaryalert.io>`_
-- `Twitter <https://twitter.com/binaryalert_io>`_ (unofficial)
 - `Slack <https://binaryalert.herokuapp.com>`_ (unofficial)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,7 +29,6 @@ Resources
 * `GitHub Repo <https://github.com/airbnb/binaryalert>`_
 * `Blog Post <https://medium.com/airbnb-engineering/binaryalert-real-time-serverless-malware-detection-ca44370c1b90>`_
 * `Slack <https://binaryalert.herokuapp.com/>`_ (unofficial)
-* `Twitter <https://twitter.com/binaryalert_io>`_ (unofficial)
 
 
 Table of Contents


### PR DESCRIPTION
to: @jacknagz or @mime-frame 
cc: @airbnb/bighead-maintainers 
size: small

The BinaryAlert Twitter account has been deleted, so we remove references to it in documentation and in the README
