### PR TITLE
Multiprocess dispatcher

### DIFF
--- a/lambda_functions/dispatcher/main.py
+++ b/lambda_functions/dispatcher/main.py
@@ -8,6 +8,7 @@
 import collections
 import json
 import logging
+from multiprocessing import Process
 import os
 from typing import Any, Dict, List
 
@@ -16,7 +17,6 @@ import boto3
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
 
-CLOUDWATCH = boto3.client('cloudwatch')
 LAMBDA = boto3.client('lambda')
 
 # Build a DispatchConfig tuple for each queue specified in the environment variables.
@@ -35,7 +35,7 @@ DISPATCH_CONFIGS = [
 ]
 
 SQS_MAX_MESSAGES = 10  # Maximum number of messages to request (highest allowed by SQS).
-WAIT_TIME_SECONDS = 3  # Maximum amount of time to hold a receive_message connection open.
+WAIT_TIME_SECONDS = 20  # Maximum amount of time to hold a receive_message connection open.
 
 
 def _invoke_lambda(queue_url: str, sqs_messages: List[Any], config: DispatchConfig) -> None:
@@ -64,36 +64,21 @@ def _invoke_lambda(queue_url: str, sqs_messages: List[Any], config: DispatchConf
     )
 
 
-def _publish_metrics(batch_sizes: Dict[str, List[int]]) -> None:
-    """Publish metrics about how many times each function was invoked, and with what batch sizes."""
-    metric_data = []
+def _sqs_poll(config: DispatchConfig, lambda_context: Any):
+    """Process entry point: long polling of a single queue."""
+    LOGGER.info('Polling process started: %s => lambda:%s:%s',
+                config.queue.url, config.lambda_name, config.lambda_qualifier)
 
-    for function_name, batches in batch_sizes.items():
-        if not batches:
-            continue
-
-        dimensions = [{'Name': 'FunctionName', 'Value': function_name}]
-        metric_data.append({
-            'MetricName': 'DispatchInvocations',
-            'Dimensions': dimensions,
-            'Value': len(batches),
-            'Unit': 'Count'
-        })
-        metric_data.append({
-            'MetricName': 'DispatchBatchSize',
-            'Dimensions': dimensions,
-            'StatisticValues': {
-                'Minimum': min(batches),
-                'Maximum': max(batches),
-                'SampleCount': len(batches),
-                'Sum': sum(batches)
-            },
-            'Unit': 'Count'
-        })
-
-    if metric_data:
-        LOGGER.info('Publishing invocation metrics')
-        CLOUDWATCH.put_metric_data(Namespace='BinaryAlert', MetricData=metric_data)
+    # Keep polling the queue until we're about to run out of time.
+    while lambda_context.get_remaining_time_in_millis() > (WAIT_TIME_SECONDS + 3) * 1000:
+        # Long-polling: blocks until at least one message is available or the connection times out.
+        sqs_messages = config.queue.receive_messages(
+            AttributeNames=['ApproximateReceiveCount'],
+            MaxNumberOfMessages=SQS_MAX_MESSAGES,
+            WaitTimeSeconds=WAIT_TIME_SECONDS
+        )
+        if sqs_messages:
+            _invoke_lambda(config.queue.url, sqs_messages, config)
 
 
 def dispatch_lambda_handler(_: Dict[str, Any], lambda_context: Any) -> None:
@@ -103,24 +88,14 @@ def dispatch_lambda_handler(_: Dict[str, Any], lambda_context: Any) -> None:
         _: Unused invocation event.
         lambda_context: LambdaContext object with .get_remaining_time_in_millis().
     """
-    # Keep track of the batch sizes (one element for each invocation) for each target function.
-    batch_sizes: Dict[str, List[int]] = {config.lambda_name: [] for config in DISPATCH_CONFIGS}
+    # Create a separate process for polling each queue.
+    processes = [Process(target=_sqs_poll, args=(config, lambda_context))
+                 for config in DISPATCH_CONFIGS]
 
-    # The maximum amount of time needed in the execution loop.
-    # This allows us to dispatch as long as possible while still staying under the time limit.
-    # We need time to wait for sqs messages as well as a few seconds (e.g. 3) to forward them.
-    loop_execution_time_ms = (WAIT_TIME_SECONDS + 3) * 1000 * len(DISPATCH_CONFIGS)
+    # Start each polling process.
+    for process in processes:
+        process.start()
 
-    while lambda_context.get_remaining_time_in_millis() > loop_execution_time_ms:
-        # Receive a batch of messages for each configured queue.
-        for config in DISPATCH_CONFIGS:
-            sqs_messages = config.queue.receive_messages(
-                AttributeNames=['ApproximateReceiveCount'],
-                MaxNumberOfMessages=SQS_MAX_MESSAGES,
-                WaitTimeSeconds=WAIT_TIME_SECONDS
-            )
-            if sqs_messages:
-                _invoke_lambda(config.queue.url, sqs_messages, config)
-                batch_sizes[config.lambda_name].append(len(sqs_messages))
-
-    _publish_metrics(batch_sizes)
+    # Wait for all of the polling processes to finish, then exit normally.
+    for process in processes:
+        process.join()

--- a/lambda_functions/dispatcher/main.py
+++ b/lambda_functions/dispatcher/main.py
@@ -64,7 +64,7 @@ def _invoke_lambda(queue_url: str, sqs_messages: List[Any], config: DispatchConf
     )
 
 
-def _sqs_poll(config: DispatchConfig, lambda_context: Any):
+def _sqs_poll(config: DispatchConfig, lambda_context: Any) -> None:
     """Process entry point: long polling of a single queue."""
     LOGGER.info('Polling process started: %s => lambda:%s:%s',
                 config.queue.url, config.lambda_name, config.lambda_qualifier)

--- a/lambda_functions/downloader/README.rst
+++ b/lambda_functions/downloader/README.rst
@@ -4,24 +4,3 @@ This optional Lambda function copies a binary from CarbonBlack Enterprise Respon
 It can invoked every time CarbonBlack logs a ``binarystore.file.added`` event over the server message bus.
 
 For more information, see the `documentation <https://binaryalert.io/uploading-files.html#carbonblack-downloader>`_.
-
-Cbapi Pip Dependency
---------------------
-The ``cbapi`` library needs to be pre-built on the AWS Lambda AMI. ``cbapi_1.3.4.zip`` is already
-included in the repo for you, but if you need to upgrade it or rebuild it, SSH to an EC2 instance
-running the
-`AWS Lambda AMI <http://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html>`_
-and install ``cbapi`` as follows:
-
-.. code-block:: bash
-
-    # Install requirements
-    sudo yum update
-    sudo yum install gcc python36
-
-    # Install cbapi and build the zipfile
-    pip-3.6 install cbapi -t ~
-    rm -r *dist-info *egg-info  # Remove unnecessary package information
-    zip -r cbapi.zip *
-
-Then you need only ``scp`` the new zip file to replace ``cbapi_1.3.4.zip``

--- a/lambda_functions/downloader/main.py
+++ b/lambda_functions/downloader/main.py
@@ -125,7 +125,7 @@ def _process_md5(md5: str) -> bool:
 def _delete_sqs_messages(queue_url: str, receipts: List[str], ) -> None:
     """Mark a batch of SQS receipts as completed (removing them from the queue)."""
     LOGGER.info('Deleting %d SQS receipt(s)', len(receipts))
-    SQS.queue(queue_url).delete_messages(
+    SQS.Queue(queue_url).delete_messages(
         Entries=[
             {'Id': str(index), 'ReceiptHandle': receipt} for index, receipt in enumerate(receipts)
         ]

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -83,11 +83,11 @@ lambda_batch_objects_per_message = 5
 lambda_batch_memory_mb = 128
 
 // How often the Lambda dispatcher will be invoked.
-lambda_dispatch_frequency_minutes = 1
+lambda_dispatch_frequency_minutes = 5
 
 // Memory and time limits for the dispatching function.
 lambda_dispatch_memory_mb = 128
-lambda_dispatch_timeout_sec = 60
+lambda_dispatch_timeout_sec = 300
 
 // Memory and time limits for the downloader function.
 lambda_download_memory_mb = 128


### PR DESCRIPTION
to: @javuto 
cc: @ryandeivert 
cc: @airbnb/binaryalert-maintainers
size: small

## Background

#112 generalized the dispatcher, but did so by alternating between the different queues and polling from each. The AWS documentation for [SQS Long Polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html) recommends instead to have different threads for each queue being polled. This way, the dispatcher is not blocked if one of its queues is empty.

## Changes

* Use one Process for each queue that the dispatcher is polling
* Fix a small bug in the downloader introduced by #112 and update the downloader README
* Instead of invoking the dispatcher every minute, invoke every 5 minutes and use the maximum long poll timeout (20 seconds)
* Remove custom metrics from the dispatcher. They are not in the dashboard and have never proved useful for troubleshooting. Built-in metrics for Lambda and SQS have proven sufficient.

## Testing

* `./manage.py configure` - enable downloader
*  `./manage.py deploy`
* `./manage.py cb_copy_all` - enqueue thousands of fake events to SQS
* `./manage.py analyze_all`
* `./manage.py configure` - remove downloader
* `./manage.py deploy` - ensure the dispatcher still works with only a single queue

The dispatcher logs show that it is interleaving events from both the analyzer and downloader queues
