### PR TITLE
Small fixes after stress test

### DIFF
--- a/lambda_functions/build.py
+++ b/lambda_functions/build.py
@@ -4,10 +4,10 @@ import os
 import pathlib
 import shutil
 import stat
+import subprocess
+import sys
 import tempfile
 import zipfile
-
-import pip
 
 from lambda_functions.analyzer.common import COMPILED_RULES_FILENAME
 from rules.compile_rules import compile_rules
@@ -84,7 +84,10 @@ def _build_downloader(target_directory: str) -> None:
         shutil.rmtree(temp_package_dir)
 
     # Pip install cbapi library (has no native dependencies).
-    pip.main(['install', '--quiet', '--target', temp_package_dir, 'cbapi==1.3.6'])
+    subprocess.check_call([
+        sys.executable, '-m', 'pip', 'install',
+        '--quiet', '--target', temp_package_dir, 'cbapi==1.3.6'
+    ])
 
     # Copy Lambda code into the package.
     shutil.copy(DOWNLOAD_SOURCE, temp_package_dir)

--- a/lambda_functions/downloader/main.py
+++ b/lambda_functions/downloader/main.py
@@ -73,8 +73,8 @@ def _download_from_carbon_black(binary: Binary) -> str:
 def _build_metadata(binary: Binary) -> Dict[str, str]:
     """Return basic metadata to make it easier to triage YARA match alerts."""
     return {
-        'carbon_black_group': ','.join(binary.group),
-        'carbon_black_host_count': str(binary.host_count),
+        'carbon_black_group': (
+            ','.join(binary.group) if isinstance(binary.group, list) else binary.group),
         'carbon_black_last_seen': binary.last_seen,
         'carbon_black_md5': binary.md5,
         'carbon_black_os_type': binary.os_type,
@@ -83,6 +83,7 @@ def _build_metadata(binary: Binary) -> Dict[str, str]:
         'filepath': (
             # Throw out any non-ascii characters (S3 metadata must be ascii).
             binary.observed_filenames[0].encode('ascii', 'ignore').decode('ascii')
+            if binary.observed_filenames else '(unknown)'
         )
     }
 

--- a/terraform/cloudwatch_dashboard.tf
+++ b/terraform/cloudwatch_dashboard.tf
@@ -83,7 +83,7 @@ EOF
   "type": "metric",
   "width": 12,
   "properties": {
-    "title": "Analyzer SQS - Age Of Oldest Message (Seconds)",
+    "title": "Analyzer SQS - Age Of Oldest Message",
     "region": "${var.aws_region}",
     "stat": "Average",
     "metrics": [
@@ -136,7 +136,7 @@ EOF
   "type": "metric",
   "width": 12,
   "properties": {
-    "title": "Downloader SQS - Age Of Oldest Message (Seconds)",
+    "title": "Downloader SQS - Age Of Oldest Message",
     "region": "${var.aws_region}",
     "stat": "Average",
     "metrics": [
@@ -197,7 +197,7 @@ EOF
   "type": "metric",
   "width": 12,
   "properties": {
-    "title": "Maximum Lambda Duration (ms)",
+    "title": "Maximum Lambda Duration",
     "region": "${var.aws_region}",
     "stat": "Maximum",
     "metrics": [
@@ -265,7 +265,7 @@ EOF
   "type": "metric",
   "width": 12,
   "properties": {
-    "title": "S3 Download Latency (ms)",
+    "title": "S3 Download Latency",
     "region": "${var.aws_region}",
     "metrics": [
       ["BinaryAlert", "S3DownloadLatency", {"label": "Minimum", "stat": "Minimum"}],
@@ -305,7 +305,7 @@ EOF
   "type": "metric",
   "width": 12,
   "properties": {
-    "title": "BinaryAlert Logs (Bytes)",
+    "title": "BinaryAlert Logs",
     "region": "${var.aws_region}",
     "stacked": true,
     "stat": "Sum",

--- a/terraform/cloudwatch_metric_alarm.tf
+++ b/terraform/cloudwatch_metric_alarm.tf
@@ -68,9 +68,9 @@ EOF
     QueueName = "${aws_sqs_queue.analyzer_queue.name}"
   }
 
-  // The queue is consistently more than 30 minutes behind.
+  // The queue is consistently more than 2 hours behind.
   comparison_operator       = "GreaterThanThreshold"
-  threshold                 = 1800
+  threshold                 = 7200
   period                    = 60
   evaluation_periods        = 15
   alarm_actions             = ["${aws_sns_topic.metric_alarms.arn}"]
@@ -95,9 +95,9 @@ EOF
     QueueName = "${aws_sqs_queue.downloader_queue.name}"
   }
 
-  // The queue is consistently more than 30 minutes behind.
+  // The queue is consistently more than 2 hours behind.
   comparison_operator       = "GreaterThanThreshold"
-  threshold                 = 1800
+  threshold                 = 7200
   period                    = 60
   evaluation_periods        = 15
   alarm_actions             = ["${aws_sns_topic.metric_alarms.arn}"]
@@ -116,8 +116,8 @@ ${aws_sqs_queue.dead_letter_queue.name}.
 EOF
 
   namespace   = "AWS/SQS"
-  metric_name = "NumberOfMessagesReceived"
-  statistic   = "Sum"
+  metric_name = "ApproximateNumberOfMessagesVisible"
+  statistic   = "Maximum"
 
   dimensions = {
     QueueName = "${aws_sqs_queue.dead_letter_queue.name}"

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -2,6 +2,9 @@
 resource "aws_sqs_queue" "analyzer_queue" {
   name = "${var.name_prefix}_binaryalert_analyzer_queue"
 
+  // Messages are dropped from the queue after 12 hours
+  message_retention_seconds = 43200
+
   // When a message is received, it will be invisible to other consumers for this long.
   // Set to just a few seconds after the lambda analyzer would timeout.
   visibility_timeout_seconds = "${format("%d", var.lambda_analyze_timeout_sec + 2)}"
@@ -43,6 +46,10 @@ resource "aws_sqs_queue_policy" "analyzer_queue_policy" {
 resource "aws_sqs_queue" "downloader_queue" {
   count = "${var.enable_carbon_black_downloader}"
   name  = "${var.name_prefix}_binaryalert_downloader_queue"
+
+  // Messages are dropped from the queue after 12 hours
+  // (In practice, the redrive policy should kick in long before then)
+  message_retention_seconds = 43200
 
   // When a message is received, it will be invisible to other consumers for this long.
   // Set to just a few seconds after the downloader would timeout.

--- a/tests/lambda_functions/build_test.py
+++ b/tests/lambda_functions/build_test.py
@@ -6,8 +6,6 @@ import unittest
 from unittest import mock
 import zipfile
 
-import pip
-
 from lambda_functions import build
 
 
@@ -110,7 +108,7 @@ class BuildTest(unittest.TestCase):
         )
         mock_print.assert_called_once()
 
-    @mock.patch.object(pip, 'main', side_effect=_mock_pip_main)
+    @mock.patch.object(build.subprocess, 'check_call', side_effect=_mock_pip_main)
     def test_build_downloader(self, mock_pip: mock.MagicMock, mock_print: mock.MagicMock):
         """Verify list of bundled files for the downloader."""
         build._build_downloader(self._tempdir)

--- a/tests/lambda_functions/downloader/main_test.py
+++ b/tests/lambda_functions/downloader/main_test.py
@@ -46,7 +46,6 @@ class MainTest(fake_filesystem_unittest.TestCase):
         self._binary = MockBinary(
             b'hello world',
             group=['Production', 'Laptops'],
-            host_count=2,
             last_seen='sometime-recently',
             md5='ABC123',
             observed_filenames=['/Users/name/file.txt'],
@@ -84,7 +83,6 @@ class MainTest(fake_filesystem_unittest.TestCase):
 
             expected_metadata = {
                 'carbon_black_group': 'Production,Laptops',
-                'carbon_black_host_count': '2',
                 'carbon_black_last_seen': 'sometime-recently',
                 'carbon_black_md5': 'ABC123',
                 'carbon_black_os_type': 'Linux',


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/binaryalert-maintainers
size: small

## Background

#112 , #113 , and #114 were some relatively big changes to BinaryAlert, and some problems surfaced when stress-testing in different environments, which we address here.

## Changes

* Use `subprocess` instead of `pip.main`, which is no longer supported in `pip` v10.0.0
* Change Downloader metadata to accommodate a wider range of possibilities introduced by the new `cbapi`
* Remove units from CloudWatch graph titles (CloudWatch now shows them in the graph itself)
* Fix the DLQ metric alarm - it should look at number of messages, not messages received
* SQS retention has been lowered from the default (4 days) to 12 hours, mostly so that the graph of message age is easier to see. In practice, messages should never stick around that long

## Testing

* Deployed to other environments
