### PR TITLE
Enable server-side encryption for Dynamo, S3, and SQS

### DIFF
--- a/lambda_functions/build.py
+++ b/lambda_functions/build.py
@@ -86,7 +86,7 @@ def _build_downloader(target_directory: str) -> None:
     # Pip install cbapi library (has no native dependencies).
     subprocess.check_call([
         sys.executable, '-m', 'pip', 'install',
-        '--quiet', '--target', temp_package_dir, 'cbapi==1.3.6'
+        '--quiet', '--target', temp_package_dir, 'cbapi==1.3.6', 'python-dateutil==2.6.1'
     ])
 
     # Copy Lambda code into the package.

--- a/lambda_functions/downloader/main.py
+++ b/lambda_functions/downloader/main.py
@@ -30,7 +30,7 @@ DECRYPTED_TOKEN = boto3.client('kms').decrypt(
 )['Plaintext']
 
 # Establish boto3 and S3 clients at import time so Lambda can cache them for re-use.
-CARBON_BLACK = cbapi.CbEnterpriseResponseAPI(
+CARBON_BLACK = cbapi.CbResponseAPI(
     url=os.environ['CARBON_BLACK_URL'], token=DECRYPTED_TOKEN)
 CLOUDWATCH = boto3.client('cloudwatch')
 S3_BUCKET = boto3.resource('s3').Bucket(os.environ['TARGET_S3_BUCKET'])

--- a/terraform/dynamo.tf
+++ b/terraform/dynamo.tf
@@ -17,6 +17,11 @@ resource "aws_dynamodb_table" "binaryalert_yara_matches" {
     type = "N"
   }
 
+  // Server-side encryption works with AWS-managed keys (no support for customer keys yet)
+  server_side_encryption {
+    enabled = true
+  }
+
   tags {
     Name = "${var.tagged_name}"
   }

--- a/terraform/lambda_iam.tf
+++ b/terraform/lambda_iam.tf
@@ -38,6 +38,13 @@ data "aws_iam_policy_document" "binaryalert_analyzer_policy" {
   }
 
   statement {
+    sid       = "DecryptSSE"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["${aws_kms_key.sse_s3.arn}"]
+  }
+
+  statement {
     sid    = "GetFromBinaryAlertBucket"
     effect = "Allow"
 
@@ -74,6 +81,18 @@ resource "aws_iam_role_policy" "binaryalert_analyzer_policy" {
 
 data "aws_iam_policy_document" "binaryalert_batcher_policy" {
   statement {
+    sid    = "UseSSE"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+
+    resources = ["${aws_kms_key.sse_sqs.arn}"]
+  }
+
+  statement {
     sid       = "InvokeBinaryAlertBatcher"
     effect    = "Allow"
     actions   = ["lambda:InvokeFunction"]
@@ -104,6 +123,13 @@ resource "aws_iam_role_policy" "binaryalert_batcher_policy" {
 // ********** Dispatcher **********
 
 data "aws_iam_policy_document" "binaryalert_dispatcher_policy_analyzer" {
+  statement {
+    sid       = "DecryptSSE"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["${aws_kms_key.sse_sqs.arn}"]
+  }
+
   statement {
     sid       = "InvokeBinaryAlertAnalyzer"
     effect    = "Allow"
@@ -154,6 +180,18 @@ resource "aws_iam_role_policy" "binaryalert_dispatcher_policy_downloader" {
 
 data "aws_iam_policy_document" "binaryalert_downloader_policy" {
   count = "${var.enable_carbon_black_downloader}"
+
+  statement {
+    sid    = "AllowSSE"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+
+    resources = ["${aws_kms_key.sse_s3.arn}"]
+  }
 
   statement {
     sid       = "DecryptCarbonBlackCredentials"

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -33,6 +33,15 @@ resource "aws_s3_bucket" "binaryalert_log_bucket" {
     target_prefix = "self/"
   }
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = "${aws_kms_key.sse_s3.arn}"
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
   tags {
     Name = "${var.tagged_name}"
   }
@@ -74,6 +83,15 @@ resource "aws_s3_bucket" "binaryalert_binaries" {
 
     expiration {
       expired_object_delete_marker = true
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = "${aws_kms_key.sse_s3.arn}"
+        sse_algorithm     = "aws:kms"
+      }
     }
   }
 

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -2,6 +2,8 @@
 resource "aws_sqs_queue" "analyzer_queue" {
   name = "${var.name_prefix}_binaryalert_analyzer_queue"
 
+  kms_master_key_id = "${aws_kms_key.sse_sqs.arn}"
+
   // Messages are dropped from the queue after 12 hours
   message_retention_seconds = 43200
 
@@ -47,6 +49,8 @@ resource "aws_sqs_queue" "downloader_queue" {
   count = "${var.enable_carbon_black_downloader}"
   name  = "${var.name_prefix}_binaryalert_downloader_queue"
 
+  kms_master_key_id = "${aws_kms_key.sse_sqs.arn}"
+
   // Messages are dropped from the queue after 12 hours
   // (In practice, the redrive policy should kick in long before then)
   message_retention_seconds = 43200
@@ -70,6 +74,8 @@ resource "aws_sqs_queue" "dead_letter_queue" {
   count                     = "${var.enable_carbon_black_downloader}"
   name                      = "${var.name_prefix}_binaryalert_sqs_dead_letter_queue"
   message_retention_seconds = 1209600
+
+  kms_master_key_id = "${aws_kms_key.sse_sqs.arn}"
 
   tags {
     Name = "${var.tagged_name}"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -5,6 +5,9 @@
 /* ********** [Auto-Configured] Base Configuration ********** */
 // These are the only settings you need to get started.
 
+// 12-digit AWS account ID
+aws_account_id = ""
+
 // AWS region in which to deploy the BinaryAlert components.
 aws_region = "us-east-1"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,6 @@
 /* See terraform.tfvars for descriptions of each of the variables. */
 
+variable "aws_account_id" {}
 variable "aws_region" {}
 variable "name_prefix" {}
 

--- a/tests/lambda_functions/build_test.py
+++ b/tests/lambda_functions/build_test.py
@@ -11,9 +11,10 @@ from lambda_functions import build
 
 def _mock_pip_main(args_list: List[str]) -> None:
     """Mock pip install just creates the target directory."""
-    directory = args_list[-2]
-    package = args_list[-1].split('==')[0]
-    os.makedirs(os.path.join(directory, package))
+    directory = args_list[6]
+    packages = args_list[7:]
+    for pkg in packages:
+        os.makedirs(os.path.join(directory, pkg.split('==')[0]))
 
 
 @mock.patch.object(build, 'print')

--- a/tests/lambda_functions/downloader/main_test.py
+++ b/tests/lambda_functions/downloader/main_test.py
@@ -68,7 +68,7 @@ class MainTest(fake_filesystem_unittest.TestCase):
 
         # Mock out cbapi and import the file under test.
         with mock.patch.object(boto3, 'client'), mock.patch.object(boto3, 'resource'), \
-                mock.patch.object(cbapi, 'CbEnterpriseResponseAPI'):
+                mock.patch.object(cbapi, 'CbResponseAPI'):
             from lambda_functions.downloader import main
             self.download_main = main
 


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers
size: medium

## Background

BinaryAlert may be processing and storing sensitive information (files scanned, YARA matches, etc). To better protect that data, we can use server-side encryption (SSE) to encrypt data at rest in all supported services (Dynamo, S3, and SQS)

## Changes

* Pins the `python-dateutil` library when building the downloader function to avoid a `pip` warning
* `CbEnterpriseResponseAPI` has been deprecated by CarbonBlack in favor of `CbResponseAPI`
* Create 2 new KMS keys for server-side encryption of S3 and SQS, respectively. (Dynamo uses its own AWS-managed key)
* Add AWS account ID to the BinaryAlert config (it's required for creating a policy on the new KMS key)

**WARNING:** Enabling server-side encryption for the Dynamo table forces a new resource, meaning it will destroy your existing table

## Testing
Verified end-to-end in a test account:

```
./manage.py configure  # No CarbonBlack
./manage.py deploy
./manage.py live_test
./manage.py configure  # Enable CarbonBlack
./manage.py deploy
./manage.py cb_copy_all  # Test the downloader
./manage.py live_test
```