### PR TITLE
Use SSE-S3 instead of SSE-KMS for access logs

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -36,8 +36,7 @@ resource "aws_s3_bucket" "binaryalert_log_bucket" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = "${aws_kms_key.sse_s3.arn}"
-        sse_algorithm     = "aws:kms"
+        sse_algorithm = "AES256"
       }
     }
   }


### PR DESCRIPTION
to: @ryandeivert 
cc: @airbnb/binaryalert-maintainers 
size: small

## Background

#121 enabled server-side encryption with KMS for both BinaryAlert S3 buckets. However, access logs could no longer be delivered after this change.

I'm sure there's a permission error, but I couldn't find it - even granting `kms:*` to `Service: s3.amazonaws.com` for the KMS key didn't work.

## Changes

Use the default S3 encryption for the access logs bucket instead of KMS. KMS is still used to encrypt the primary bucket (for uploads)

## Testing

* Access logs delivered successfully after this change
