### PR TITLE
Bump PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ pylint==1.8.4
 pyparsing==2.2.0
 python-dateutil==2.6.1
 pytz==2018.4
-PyYAML==3.12
+PyYAML==3.13
 requests==2.18.4
 responses==0.9.0
 s3transfer==0.1.13


### PR DESCRIPTION
to: @airbnb/binaryalert-maintainers
cc:
size: small
resolves #127

## Background

See #127

## Changes

* Bump PyYAML to 3.13

## Testing

Just started trying out binaryalert, `unit_test` still works:
```
(tmp-2ead4cdaa0183929) % ./manage.py unit_test
..................................................................................
----------------------------------------------------------------------
Ran 82 tests in 4.083s

OK
```
