### PR TITLE
More configuration options and support direct invocation

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -123,14 +123,14 @@ class BinaryAlertConfig:
         self._config['name_prefix'] = value
 
     @property
-    def enable_carbon_black_downloader(self) -> int:
+    def enable_carbon_black_downloader(self) -> bool:
         return self._config['enable_carbon_black_downloader']
 
     @enable_carbon_black_downloader.setter
-    def enable_carbon_black_downloader(self, value: int) -> None:
-        if value not in {0, 1}:
+    def enable_carbon_black_downloader(self, value: bool) -> None:
+        if not isinstance(value, bool):
             raise InvalidConfigError(
-                'enable_carbon_black_downloader "{}" must be either 0 or 1.'.format(value)
+                'enable_carbon_black_downloader "{}" must be a boolean.'.format(value)
             )
         self._config['enable_carbon_black_downloader'] = value
 
@@ -252,7 +252,7 @@ class BinaryAlertConfig:
         get_input('Unique name prefix, e.g. "company_team"', self.name_prefix, self, 'name_prefix')
         enable_downloader = get_input('Enable the CarbonBlack downloader?',
                                       'yes' if self.enable_carbon_black_downloader else 'no')
-        self.enable_carbon_black_downloader = 1 if enable_downloader == 'yes' else 0
+        self.enable_carbon_black_downloader = (enable_downloader == 'yes')
 
         if self.enable_carbon_black_downloader:
             self._configure_carbon_black()

--- a/lambda_functions/analyzer/analyzer_aws_lib.py
+++ b/lambda_functions/analyzer/analyzer_aws_lib.py
@@ -70,29 +70,14 @@ def _elide_string_middle(text: str, max_length: int) -> str:
     return '{} ... {}'.format(text[:half_len], text[-half_len:])
 
 
-def publish_alert_to_sns(binary: BinaryInfo, topic_arn: str) -> None:
+def publish_to_sns(binary: BinaryInfo, topic_arn: str, subject: str) -> None:
     """Publish a JSON SNS alert: a binary has matched one or more YARA rules.
 
     Args:
         binary: Instance containing information about the binary.
         topic_arn: Publish to this SNS topic ARN.
+        subject: Message subject (for email subscriptions to the topic)
     """
-    subject = '[BinaryAlert] {} matches a YARA rule'.format(
-        binary.filepath or binary.computed_sha)
-    SNS.Topic(topic_arn).publish(
-        Subject=_elide_string_middle(subject, SNS_PUBLISH_SUBJECT_MAX_SIZE),
-        Message=(json.dumps(binary.summary(), indent=4, sort_keys=True))
-    )
-
-def publish_safe_to_sns(binary: BinaryInfo, topic_arn: str) -> None:
-    """Publish a JSON SNS alert: a binary has matched none and is safe.
-
-    Args:
-        binary: Instance containing information about the binary.
-        topic_arn: Publish to this SNS topic ARN.
-    """
-    subject = '[BinaryAlert] {} is a safe file'.format(
-        binary.filepath or binary.computed_sha)
     SNS.Topic(topic_arn).publish(
         Subject=_elide_string_middle(subject, SNS_PUBLISH_SUBJECT_MAX_SIZE),
         Message=(json.dumps(binary.summary(), indent=4, sort_keys=True))

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Command-line tool for easily managing BinaryAlert."""
 import argparse
+import os
 import sys
 
 from cli import __version__
@@ -23,6 +24,7 @@ def main() -> None:
         '--version', action='version', version='BinaryAlert v{}'.format(__version__))
     args = parser.parse_args()
 
+    os.environ['TF_IN_AUTOMATION'] = '1'
     manager.run(args.command)
 
 

--- a/terraform/cloudwatch_dashboard.tf
+++ b/terraform/cloudwatch_dashboard.tf
@@ -179,7 +179,7 @@ EOF
         "FunctionName", "${module.binaryalert_analyzer.function_name}",
         {"label": "Analyzer"}
       ]
-      ${var.enable_carbon_black_downloader == 1 ? local.downloader : ""}
+      ${var.enable_carbon_black_downloader ? local.downloader : ""}
     ]
   }
 }
@@ -199,7 +199,7 @@ EOF
         "FunctionName", "${module.binaryalert_analyzer.function_name}",
         {"label": "Analyzer"}
       ]
-      ${var.enable_carbon_black_downloader == 1 ? local.downloader : ""}
+      ${var.enable_carbon_black_downloader ? local.downloader : ""}
     ],
     "annotations": {
       "horizontal": [
@@ -227,7 +227,7 @@ EOF
         "FunctionName", "${module.binaryalert_analyzer.function_name}",
         {"label": "Analyzer"}
       ]
-      ${var.enable_carbon_black_downloader == 1 ? local.downloader : ""}
+      ${var.enable_carbon_black_downloader ? local.downloader : ""}
     ]
   }
 }
@@ -247,7 +247,7 @@ EOF
         "FunctionName", "${module.binaryalert_analyzer.function_name}",
         {"label": "Analyzer"}
       ]
-      ${var.enable_carbon_black_downloader == 1 ? local.downloader : ""}
+      ${var.enable_carbon_black_downloader ? local.downloader : ""}
     ]
   }
 }
@@ -283,7 +283,7 @@ EOF
         "TopicName", "${aws_sns_topic.yara_match_alerts.name}",
         {"label": "YARA Match Alerts"}
       ],
-      [".", ".", ".", "${aws_sns_topic.metric_alarms.name}", {"label": "Metric Alarms"}]
+      [".", ".", ".", "${element(split(":", local.alarm_target), 5)}", {"label": "Metric Alarms"}]
     ]
   }
 }
@@ -308,7 +308,7 @@ EOF
         "LogGroupName", "${module.binaryalert_analyzer.log_group_name}",
         {"label": "Analyzer"}
       ]
-      ${var.enable_carbon_black_downloader == 1 ? local.downloader_logs : ""}
+      ${var.enable_carbon_black_downloader ? local.downloader_logs : ""}
     ]
   }
 }
@@ -341,7 +341,7 @@ EOF
 }
 EOF
 
-  dashboard_body = "${var.enable_carbon_black_downloader == 1 ? local.dashboard_body_with_downloader : local.dashboard_body_without_downloader}"
+  dashboard_body = "${var.enable_carbon_black_downloader ? local.dashboard_body_with_downloader : local.dashboard_body_without_downloader}"
 }
 
 resource "aws_cloudwatch_dashboard" "binaryalert" {

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -65,7 +65,7 @@ resource "aws_kms_alias" "sse_sqs_alias" {
 
 // KMS key to encrypt CarbonBlack credentials
 resource "aws_kms_key" "carbon_black_credentials" {
-  count               = "${var.enable_carbon_black_downloader}"
+  count               = "${var.enable_carbon_black_downloader ? 1 : 0}"
   description         = "Encrypts CarbonBlack credentials for the BinaryAlert downloader."
   enable_key_rotation = true
 
@@ -75,7 +75,7 @@ resource "aws_kms_key" "carbon_black_credentials" {
 }
 
 resource "aws_kms_alias" "encrypt_credentials_alias" {
-  count         = "${var.enable_carbon_black_downloader}"
+  count         = "${var.enable_carbon_black_downloader ? 1 : 0}"
   name          = "alias/${var.name_prefix}_binaryalert_carbonblack_credentials"
   target_key_id = "${aws_kms_key.carbon_black_credentials.key_id}"
 }

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -3,13 +3,14 @@ resource "aws_sns_topic" "yara_match_alerts" {
   name = "${var.name_prefix}_binaryalert_yara_match_alerts"
 }
 
-// CloudWatch metric alarms notify this SNS topic.
-resource "aws_sns_topic" "metric_alarms" {
-  name = "${var.name_prefix}_binaryalert_metric_alarms"
+// If a file does NOT match any YARA rules, notify this SNS topic.
+resource "aws_sns_topic" "no_yara_match" {
+  count = "${var.enable_negative_match_alerts ? 1 : 0}"
+  name  = "${var.name_prefix}_binaryalert_no_yara_match"
 }
 
-//No YARA match alerts will be published to this SNS topic.
-resource "aws_sns_topic" "safe_alerts" {
-  count = "${var.enable_safe_alerts == "1" ? 1 : 0}"
-  name  = "${var.name_prefix}_binaryalert_safe_alerts"
+// CloudWatch metric alarms notify this SNS topic (created only if an existing one is not specified)
+resource "aws_sns_topic" "metric_alarms" {
+  count = "${var.metric_alarm_sns_topic_arn == "" ? 1 : 0}"
+  name  = "${var.name_prefix}_binaryalert_metric_alarms"
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -14,17 +14,16 @@ aws_region = "us-east-1"
 // Prefix used in all resource names (required for uniqueness). E.g. "company_team"
 name_prefix = ""
 
-//option for safe alerts to be enabled
-enable_safe_alerts = 0
 
 /* ********** [Auto-Configured] Optional CarbonBlack Downloader ********** */
-enable_carbon_black_downloader = 0
+enable_carbon_black_downloader = false
 
 // URL of the CarbonBlack server.
 carbon_black_url = ""
 
 // The encrypted CarbonBlack API token will automatically be generated and saved here:
 encrypted_carbon_black_api_token = ""
+
 
 /* ********** Log Retention ********** */
 // Pre-existing bucket in which to store S3 access logs. If not specified, one will be created.
@@ -48,6 +47,9 @@ tagged_name = "BinaryAlert"
 
 
 // ##### Alarms #####
+// Use an existing SNS topic for metric alarms (instead of creating one automatically).
+metric_alarm_sns_topic_arn = ""
+
 // Alarm if no binaries are analyzed for this amount of time.
 expected_analysis_frequency_minutes = 30
 
@@ -91,14 +93,28 @@ lambda_download_concurrency_limit = 100
 // `terraform destroy`
 force_destroy = true
 
+// If using BinaryAlert to scan existing S3 buckets, add the S3 and KMS resource ARNs here to grant
+// the appropriate permissions to the analyzer Lambda function.
+external_s3_bucket_resources = []
+external_kms_key_resources = []
+
+
+// ##### SNS #####
+// Create a separate SNS topic which reports files that do NOT match any YARA rules.
+enable_negative_match_alerts = false
+
 
 // ##### SQS #####
 // Maximum number of messages that will be received by each invocation of the respective function.
 analyze_queue_batch_size = 10
 download_queue_batch_size = 1
 
+// Messages in the queue will be retained and retried for the specified duration until expiring.
+analyze_queue_retention_secs = 86400
+download_queue_retention_secs = 86400
+
 // During a retroactive scan, number of S3 objects to pack into a single SQS message.
-objects_per_retro_message = 5
+objects_per_retro_message = 4
 
 // If an SQS message is not deleted (successfully processed) after the max number of receive
 // attempts, the message is delivered to the SQS dead-letter queue.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,7 +4,6 @@ variable "aws_account_id" {}
 variable "aws_region" {}
 variable "name_prefix" {}
 
-variable "enable_safe_alerts" {}
 variable "enable_carbon_black_downloader" {}
 variable "carbon_black_url" {}
 variable "encrypted_carbon_black_api_token" {}
@@ -16,6 +15,7 @@ variable "lambda_log_retention_days" {}
 
 variable "tagged_name" {}
 
+variable "metric_alarm_sns_topic_arn" {}
 variable "expected_analysis_frequency_minutes" {}
 
 variable "dynamo_read_capacity" {}
@@ -30,7 +30,19 @@ variable "lambda_download_concurrency_limit" {}
 
 variable "force_destroy" {}
 
+variable "external_s3_bucket_resources" {
+  type = "list"
+}
+
+variable "external_kms_key_resources" {
+  type = "list"
+}
+
+variable "enable_negative_match_alerts" {}
+
 variable "analyze_queue_batch_size" {}
 variable "download_queue_batch_size" {}
+variable "analyze_queue_retention_secs" {}
+variable "download_queue_retention_secs" {}
 variable "objects_per_retro_message" {}
 variable "download_queue_max_receives" {}

--- a/tests/cli/_common.py
+++ b/tests/cli/_common.py
@@ -45,7 +45,7 @@ class FakeFilesystemBase(fake_filesystem_unittest.TestCase):
                 'aws_account_id = "{}"'.format(account_id),
                 'aws_region = "{}" // comment2'.format(region),
                 'name_prefix = "{}" // comment3'.format(prefix),
-                'enable_carbon_black_downloader = {}'.format(1 if enable_downloader else 0),
+                'enable_carbon_black_downloader = {}'.format(str(enable_downloader).lower()),
                 'carbon_black_url = "{}" //comment4'.format(cb_url),
                 'encrypted_carbon_black_api_token = "{}"'.format(encrypted_api_token),
                 'force_destroy = false',

--- a/tests/cli/config_test.py
+++ b/tests/cli/config_test.py
@@ -25,7 +25,7 @@ class BinaryAlertConfigTestFakeFilesystem(FakeFilesystemBase):
         self.assertEqual('123412341234', config.aws_account_id)
         self.assertEqual('us-test-1', config.aws_region)
         self.assertEqual('test_prefix', config.name_prefix)
-        self.assertEqual(1, config.enable_carbon_black_downloader)
+        self.assertEqual(True, config.enable_carbon_black_downloader)
         self.assertEqual('https://cb-example.com', config.carbon_black_url)
         self.assertEqual('A' * 100, config.encrypted_carbon_black_api_token)
         self.assertEqual('test.prefix.binaryalert-binaries.us-test-1',
@@ -182,7 +182,7 @@ class BinaryAlertConfigTestFakeFilesystem(FakeFilesystemBase):
         config._config['force_destroy'] = True
         config.aws_region = 'us-west-2'
         config.name_prefix = 'new_name_prefix'
-        config.enable_carbon_black_downloader = 0
+        config.enable_carbon_black_downloader = False
         config.carbon_black_url = 'https://example2.com'
         config.encrypted_carbon_black_api_token = 'B' * 100
         config.save()


### PR DESCRIPTION
to: @chunyong-lin 
cc: @airbnb/binaryalert-maintainers
size: medium

## Background

A few additional configuration options and improved support for direct invocation and scanning external resources.

## Changes

* Use `true/false` for all "boolean" Terraform values (instead of 0/1)
* Rename `safe_alert` to "negative" or "no-match" alert and consolidate some of the SNS logic (FYI @goochi1 )
* Add support for direct invocation of the BinaryAlert analyzer with an extremely simple event:

```json
{
    "BucketName": "bucket-name",
    "ObjectKeys": ["key1", "key2"]
}
```

* An existing SNS topic can be used for metric alarms instead of always creating one
* Queue retention periods are now configurable and the associated metric alarms will automatically adjust - alarms will trigger if the oldest message in the queue reaches 75% of the retention period
* Existing S3 buckets and KMS keys can be listed in the BinaryAlert config to automatically grant permissions for scanning external resources
* Set the [`TF_IN_AUTOMATION` env variable ](https://www.terraform.io/guides/running-terraform-in-automation.html#controlling-terraform-output-in-automation) to suppress some noisy Terraform output. In particular, the `terraform init` now only prints a single line instead of a whole paragraph

## Testing

* Deploy to a test account
* Set `metric_alarm_sns_topic_arn` and redeploy
* Set `external_s3_bucket_resources` and `external_kms_key_resources` and redeploy
* Invoke the BinaryAlert analyzer directly with an encrypted object in an S3 bucket not owned by BinaryAlert
* Set `enable_negative_match_alerts = true` and redeploy
* Invoke analyzer directly again, verifying alerts are sent and not sent when expected
* Destroy
