### PR TITLE
Fix pyfakefs deprecation warnings

### DIFF
--- a/tests/cli/_common.py
+++ b/tests/cli/_common.py
@@ -61,10 +61,10 @@ class FakeFilesystemBase(fake_filesystem_unittest.TestCase):
         # pyhcl automatically writes "parsetab.dat" in its site-package path.
         for path in sys.path:
             if path.endswith('site-packages'):
-                self.fs.MakeDirectories(os.path.join(path, 'hcl'))
+                self.fs.makedirs(os.path.join(path, 'hcl'))
 
         # Create variables.tf file (and terraform/ directory).
-        self.fs.CreateFile(
+        self.fs.create_file(
             VARIABLES_FILE,
             contents='\n'.join([
                 'variable "aws_account_id" {}',

--- a/tests/lambda_functions/analyzer/file_hash_test.py
+++ b/tests/lambda_functions/analyzer/file_hash_test.py
@@ -15,11 +15,11 @@ class FileUtilsTest(fake_filesystem_unittest.TestCase):
         """Enable the fake filesystem and write some test files."""
         self.setUpPyfakefs()
 
-        self.fs.CreateFile('/empty_file', contents='')
+        self.fs.create_file('/empty_file', contents='')
 
         self._test_contents = 'Hello, World! This is a test file.'
         self._file_size = len(self._test_contents)
-        self.fs.CreateFile('/hello_world', contents=self._test_contents)
+        self.fs.create_file('/hello_world', contents=self._test_contents)
 
     def test_read_in_chunks(self):
         """File chunking works with different size chunks."""

--- a/tests/lambda_functions/analyzer/yara_analyzer_test.py
+++ b/tests/lambda_functions/analyzer/yara_analyzer_test.py
@@ -59,7 +59,7 @@ class YaraAnalyzerTest(fake_filesystem_unittest.TestCase):
 
         # Write target file.
         # pylint: disable=no-member
-        self.fs.CreateFile('./target.exe', contents='This is definitely not an evil file. ^_^\n')
+        self.fs.create_file('./target.exe', contents='This is definitely not an evil file. ^_^\n')
 
     @staticmethod
     def _rule_id(match):

--- a/tests/rules/clone_rules_test.py
+++ b/tests/rules/clone_rules_test.py
@@ -66,7 +66,7 @@ class CloneRulesTest(fake_filesystem_unittest.TestCase):
         os.makedirs(clone_rules.RULES_DIR)
 
         # Add fake rule sources.
-        self.fs.CreateFile(clone_rules.REMOTE_RULE_SOURCES, contents=json.dumps(
+        self.fs.create_file(clone_rules.REMOTE_RULE_SOURCES, contents=json.dumps(
             {
                 "repos": [
                     {
@@ -86,13 +86,13 @@ class CloneRulesTest(fake_filesystem_unittest.TestCase):
         ))
 
         # Add extra rules (which should be deleted).
-        self.fs.CreateFile(os.path.join(
+        self.fs.create_file(os.path.join(
             clone_rules.RULES_DIR,
             'github.com', 'test-user1', 'test-repo1', 'CVE_Rules', 'delete-me.yara'
         ))
 
         # Add some other rules (which should be preserved).
-        self.fs.CreateFile(os.path.join(clone_rules.RULES_DIR, 'private', 'private.yara'))
+        self.fs.create_file(os.path.join(clone_rules.RULES_DIR, 'private', 'private.yara'))
 
     def _mock_git_clone(self, args: List[str]) -> None:
         """Mock out git clone by creating the "cloned" directory."""
@@ -100,14 +100,14 @@ class CloneRulesTest(fake_filesystem_unittest.TestCase):
 
         # Create "cloned" directory and subfolders.
         if cloned_repo_root.endswith('test-repo1'):
-            self.fs.CreateFile(os.path.join(cloned_repo_root, 'yara', 'cloned.yara'))
-            self.fs.CreateFile(os.path.join(cloned_repo_root, 'not_included.yara'))
+            self.fs.create_file(os.path.join(cloned_repo_root, 'yara', 'cloned.yara'))
+            self.fs.create_file(os.path.join(cloned_repo_root, 'not_included.yara'))
         elif cloned_repo_root.endswith('test-repo2'):
-            self.fs.CreateFile(os.path.join(cloned_repo_root, 'yara', 'cloned.yara'))
-            self.fs.CreateFile(os.path.join(cloned_repo_root, 'yara', 'exluded_mobile.yara'))
-            self.fs.CreateFile(os.path.join(cloned_repo_root, 'windows', 'excluded.yara'))
+            self.fs.create_file(os.path.join(cloned_repo_root, 'yara', 'cloned.yara'))
+            self.fs.create_file(os.path.join(cloned_repo_root, 'yara', 'exluded_mobile.yara'))
+            self.fs.create_file(os.path.join(cloned_repo_root, 'windows', 'excluded.yara'))
         elif cloned_repo_root.endswith('test-repo3'):
-            self.fs.CreateFile(os.path.join(cloned_repo_root, 'yara', 'cloned.yara'))
+            self.fs.create_file(os.path.join(cloned_repo_root, 'yara', 'cloned.yara'))
 
     @mock.patch.object(clone_rules, 'print')
     def test_clone_remote_rules(self, mock_print: mock.MagicMock):

--- a/tests/rules/compile_rules_test.py
+++ b/tests/rules/compile_rules_test.py
@@ -25,25 +25,25 @@ class FindYaraFilesTest(fake_filesystem_unittest.TestCase):
 
     def test_find_yara_rules(self):
         """Make sure all .yar and .yara files are found."""
-        self.fs.CreateFile('/rules/file1.yar')
-        self.fs.CreateFile('/rules/file2.yara')
-        self.fs.CreateFile('/rules/community/nested.yar')
-        self.fs.CreateFile('/rules/a/b/c/d/e/deep_nested.yara')
+        self.fs.create_file('/rules/file1.yar')
+        self.fs.create_file('/rules/file2.yara')
+        self.fs.create_file('/rules/community/nested.yar')
+        self.fs.create_file('/rules/a/b/c/d/e/deep_nested.yara')
         expected = ['a/b/c/d/e/deep_nested.yara', 'community/nested.yar', 'file1.yar', 'file2.yara']
         self.assertEqual(expected, self._sorted_find())
 
     def test_find_yara_rules_mixed_case(self):
         """Uppercase .yar or .yara extensions are allowed, but the original filename is returned."""
-        self.fs.CreateFile('/rules/file1.YAR')
-        self.fs.CreateFile('/rules/file2.YaRa')
+        self.fs.create_file('/rules/file1.YAR')
+        self.fs.create_file('/rules/file2.YaRa')
         self.assertEqual(['file1.YAR', 'file2.YaRa'], self._sorted_find())
 
     def test_find_yara_rules_skip_other_files(self):
         """Non-YARA files are skipped during the traversal."""
-        self.fs.CreateFile('/rules/clone_rules.py')
-        self.fs.CreateFile('/rules/compile_rules.py')
-        self.fs.CreateFile('/rules/eicar.yar')
-        self.fs.CreateFile('/rules/README.md')
+        self.fs.create_file('/rules/clone_rules.py')
+        self.fs.create_file('/rules/compile_rules.py')
+        self.fs.create_file('/rules/eicar.yar')
+        self.fs.create_file('/rules/README.md')
         self.assertEqual(['eicar.yar'], self._sorted_find())
 
 


### PR DESCRIPTION
to: @airbnb/binaryalert-maintainers
size: small

## Background

The unit tests make a few calls to deprecated pyfakefs functions which are throwing warnings. When those functions are eventually removed this could break. Until then it clutters the test output.

An example of the output can be seen in [Travis][ci].

## Changes

* Update a few deprecated pyfakefs functions to the new versions

## Testing

```
./manage.py unit_test
.............................................................................
----------------------------------------------------------------------
Ran 77 tests in 5.601s

OK
```

[ci]: https://travis-ci.org/airbnb/binaryalert/jobs/498882125