### PR TITLE
Bump pyhcl, ply patch versions to fix build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,13 +32,13 @@ mypy-extensions==0.4.1
 packaging==19.0
 pbr==5.1.2
 pika==0.13.0
-ply==3.10
+ply==3.11
 prompt-toolkit==2.0.9
 protobuf==3.6.1
 pycparser==2.19
 pyfakefs==3.5.7
 Pygments==2.3.1
-pyhcl==0.3.10
+pyhcl==0.3.11
 pylint==2.2.2
 pyOpenSSL==19.0.0
 pyparsing==2.3.1


### PR DESCRIPTION
to: @airbnb/binaryalert-maintainers
size: small

## Background

There is a [known issue][issue] with pyhcl v0.3.10 erroring out on install. This does not appear to be actually breaking anything but it a bit of noise in the build. See the [last Travis build][ci] for an example.

## Changes

* Bump pyhcl one patch version to v0.3.11
* Bump ply one patch version to v3.11

## Testing

I am no longer seeing the build error on `pip3 install` anymore.

[issue]: https://github.com/virtuald/pyhcl/issues/39
[ci]: https://travis-ci.org/airbnb/binaryalert/jobs/499913151