### PR TITLE
Improves error handling to correctly retry downloading md5s

### DIFF
--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -60,7 +60,10 @@ variable "alarm_errors_help" {
 
 variable "alarm_errors_threshold" {
   description = "If at least this many errors occur within alarm_errors_interval_secs, a metric alarm will trigger"
-  default     = 1
+  # The error threshold has been increased significantly; this is due to a recent change that
+  # retries HTTP 404s by raising errors on Lambda, designed to accommodate for race conditions
+  # on the availability of the binary resource.
+  default     = 250
 }
 
 variable "alarm_errors_interval_secs" {


### PR DESCRIPTION
to: @airbnb/binaryalert-maintainers 
cc: 
size: small


## Background

A recent change in our Binary exfill service is causing a race condition where the triggering event is firing before the resource is actually available through the API. This causes the URL to 404. Currently, BinaryAlert WILL NOT RETRY downloading, thus dropping the analysis of that file.

The issue is that the binary will eventually show up, typically within a few minutes. Changing the handling to 404 will cause the binary to 

## Changes

* ObjectNotFoundErrors (HTTP 404) will now retry. This is accompanied by logging that explicitly states that it will retry.
* Internal server errors encountered will now also retry. Improved verbiage that explicitly states that it will retry.
* Raises the error threshold on the downloader to 250. We already have an alarm called `aws_cloudwatch_metric_alarm.downloader_sqs_age` which detects if messages are super old so I think that will handle the case where the downloader gets "stuck"

## Testing

CI?
