### PR TITLE
Sk/terraform changes

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,6 +1,6 @@
 // Create the analyzer Lambda function.
 module "binaryalert_analyzer" {
-  source          = "modules/lambda"
+  source          = "./modules/lambda"
   function_name   = "${var.name_prefix}_binaryalert_analyzer"
   description     = "Analyze a binary with a set of YARA rules"
   base_policy_arn = "${aws_iam_policy.base_policy.arn}"
@@ -37,7 +37,7 @@ resource "aws_lambda_event_source_mapping" "analyzer_via_sqs" {
 module "binaryalert_downloader" {
   enabled = "${var.enable_carbon_black_downloader ? 1 : 0}"
 
-  source          = "modules/lambda"
+  source          = "./modules/lambda"
   function_name   = "${var.name_prefix}_binaryalert_downloader"
   description     = "Copies binaries from CarbonBlack into the BinaryAlert S3 bucket"
   base_policy_arn = "${aws_iam_policy.base_policy.arn}"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,6 +6,7 @@ variable "name_prefix" {}
 
 variable "enable_carbon_black_downloader" {}
 variable "carbon_black_url" {}
+variable "carbon_black_timeout" {}
 variable "encrypted_carbon_black_api_token" {}
 
 variable "s3_log_bucket" {}


### PR DESCRIPTION
to: @airbnb/binaryalert-maintainers 
size: small
resolves #<related-issue-goes-here>

## Background
I just started to setup binary alert in my environment. I had two issues wrt terraform. 

1. Referencing the local terraform modules. 
2. missed carbon_black_timeout terraform variable. 

## Changes

* Summary of changes
* ...

## Testing

Steps for how this change was tested and verified
