### PR TITLE
Upgrades terraform modules to Terraform 0.12.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ protobuf==3.6.1
 pycparser==2.19
 pyfakefs==3.5.7
 Pygments==2.3.1
-pyhcl==0.3.10
+pyhcl==0.4.0
 pylint==2.2.2
 pyOpenSSL==19.0.0
 pyparsing==2.3.1

--- a/terraform/dynamo.tf
+++ b/terraform/dynamo.tf
@@ -3,8 +3,8 @@ resource "aws_dynamodb_table" "binaryalert_yara_matches" {
   name           = "${var.name_prefix}_binaryalert_matches"
   hash_key       = "SHA256"
   range_key      = "AnalyzerVersion"
-  read_capacity  = "${var.dynamo_read_capacity}"
-  write_capacity = "${var.dynamo_write_capacity}"
+  read_capacity  = var.dynamo_read_capacity
+  write_capacity = var.dynamo_write_capacity
 
   // Only attributes used as hash/range keys are defined here.
   attribute {
@@ -22,7 +22,8 @@ resource "aws_dynamodb_table" "binaryalert_yara_matches" {
     enabled = true
   }
 
-  tags {
-    Name = "${var.tagged_name}"
+  tags = {
+    Name = var.tagged_name
   }
 }
+

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -34,16 +34,16 @@ resource "aws_kms_key" "sse_s3" {
   description         = "BinaryAlert Server-Side Encryption - S3"
   enable_key_rotation = true
 
-  tags {
-    Name = "${var.tagged_name}"
+  tags = {
+    Name = var.tagged_name
   }
 
-  policy = "${data.aws_iam_policy_document.kms_allow_s3.json}"
+  policy = data.aws_iam_policy_document.kms_allow_s3.json
 }
 
 resource "aws_kms_alias" "sse_s3_alias" {
   name          = "alias/${var.name_prefix}_binaryalert_sse_s3"
-  target_key_id = "${aws_kms_key.sse_s3.key_id}"
+  target_key_id = aws_kms_key.sse_s3.key_id
 }
 
 // KMS key for server-side encryption (SSE) of SQS
@@ -51,31 +51,32 @@ resource "aws_kms_key" "sse_sqs" {
   description         = "BinaryAlert Server-Side Encryption - SQS"
   enable_key_rotation = true
 
-  tags {
-    Name = "${var.tagged_name}"
+  tags = {
+    Name = var.tagged_name
   }
 
-  policy = "${data.aws_iam_policy_document.kms_allow_s3.json}"
+  policy = data.aws_iam_policy_document.kms_allow_s3.json
 }
 
 resource "aws_kms_alias" "sse_sqs_alias" {
   name          = "alias/${var.name_prefix}_binaryalert_sse_sqs"
-  target_key_id = "${aws_kms_key.sse_sqs.key_id}"
+  target_key_id = aws_kms_key.sse_sqs.key_id
 }
 
 // KMS key to encrypt CarbonBlack credentials
 resource "aws_kms_key" "carbon_black_credentials" {
-  count               = "${var.enable_carbon_black_downloader ? 1 : 0}"
+  count               = var.enable_carbon_black_downloader ? 1 : 0
   description         = "Encrypts CarbonBlack credentials for the BinaryAlert downloader."
   enable_key_rotation = true
 
-  tags {
-    Name = "${var.tagged_name}"
+  tags = {
+    Name = var.tagged_name
   }
 }
 
 resource "aws_kms_alias" "encrypt_credentials_alias" {
-  count         = "${var.enable_carbon_black_downloader ? 1 : 0}"
+  count         = var.enable_carbon_black_downloader ? 1 : 0
   name          = "alias/${var.name_prefix}_binaryalert_carbonblack_credentials"
-  target_key_id = "${aws_kms_key.carbon_black_credentials.key_id}"
+  target_key_id = aws_kms_key.carbon_black_credentials[0].key_id
 }
+

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,69 +1,71 @@
 // Create the analyzer Lambda function.
 module "binaryalert_analyzer" {
-  source          = "modules/lambda"
+  source          = "./modules/lambda"
   function_name   = "${var.name_prefix}_binaryalert_analyzer"
   description     = "Analyze a binary with a set of YARA rules"
-  base_policy_arn = "${aws_iam_policy.base_policy.arn}"
+  base_policy_arn = aws_iam_policy.base_policy.arn
   handler         = "lambda_functions.analyzer.main.analyze_lambda_handler"
-  memory_size_mb  = "${var.lambda_analyze_memory_mb}"
-  timeout_sec     = "${var.lambda_analyze_timeout_sec}"
+  memory_size_mb  = var.lambda_analyze_memory_mb
+  timeout_sec     = var.lambda_analyze_timeout_sec
   filename        = "lambda_analyzer.zip"
 
-  reserved_concurrent_executions = "${var.lambda_analyze_concurrency_limit}"
+  reserved_concurrent_executions = var.lambda_analyze_concurrency_limit
 
   environment_variables = {
-    NO_MATCHES_SNS_TOPIC_ARN       = "${element(concat(aws_sns_topic.no_yara_match.*.arn, list("")), 0)}"
-    YARA_MATCHES_DYNAMO_TABLE_NAME = "${aws_dynamodb_table.binaryalert_yara_matches.name}"
-    YARA_ALERTS_SNS_TOPIC_ARN      = "${aws_sns_topic.yara_match_alerts.arn}"
+    NO_MATCHES_SNS_TOPIC_ARN       = element(concat(aws_sns_topic.no_yara_match.*.arn, [""]), 0)
+    YARA_MATCHES_DYNAMO_TABLE_NAME = aws_dynamodb_table.binaryalert_yara_matches.name
+    YARA_ALERTS_SNS_TOPIC_ARN      = aws_sns_topic.yara_match_alerts.arn
   }
 
-  log_retention_days = "${var.lambda_log_retention_days}"
-  tagged_name        = "${var.tagged_name}"
+  log_retention_days = var.lambda_log_retention_days
+  tagged_name        = var.tagged_name
 
   // There may be a few errors during a batch analysis when waiting on S3
   alarm_errors_threshold     = 10
   alarm_errors_interval_secs = 300
-  alarm_sns_arns             = ["${local.alarm_target}"]
+  alarm_sns_arns             = [local.alarm_target]
 }
 
 // Invoke analyzer Lambda from analyzer SQS queue.
 resource "aws_lambda_event_source_mapping" "analyzer_via_sqs" {
-  batch_size       = "${var.analyze_queue_batch_size}"
-  event_source_arn = "${aws_sqs_queue.analyzer_queue.arn}"
-  function_name    = "${module.binaryalert_analyzer.alias_arn}"
+  batch_size       = var.analyze_queue_batch_size
+  event_source_arn = aws_sqs_queue.analyzer_queue.arn
+  function_name    = module.binaryalert_analyzer.alias_arn
 }
 
 // Create the CarbonBlack downloading Lambda function.
 module "binaryalert_downloader" {
-  enabled = "${var.enable_carbon_black_downloader ? 1 : 0}"
-
-  source          = "modules/lambda"
+  enabled         = var.enable_carbon_black_downloader ? 1 : 0
+  source          = "./modules/lambda"
   function_name   = "${var.name_prefix}_binaryalert_downloader"
   description     = "Copies binaries from CarbonBlack into the BinaryAlert S3 bucket"
-  base_policy_arn = "${aws_iam_policy.base_policy.arn}"
+  base_policy_arn = aws_iam_policy.base_policy.arn
   handler         = "lambda_functions.downloader.main.download_lambda_handler"
-  memory_size_mb  = "${var.lambda_download_memory_mb}"
-  timeout_sec     = "${var.lambda_download_timeout_sec}"
+  memory_size_mb  = var.lambda_download_memory_mb
+  timeout_sec     = var.lambda_download_timeout_sec
   filename        = "lambda_downloader.zip"
 
-  reserved_concurrent_executions = "${var.lambda_download_concurrency_limit}"
+  reserved_concurrent_executions = var.lambda_download_concurrency_limit
 
   environment_variables = {
-    CARBON_BLACK_URL                 = "${var.carbon_black_url}"
-    CARBON_BLACK_TIMEOUT             = "${var.carbon_black_timeout}"
-    ENCRYPTED_CARBON_BLACK_API_TOKEN = "${var.encrypted_carbon_black_api_token}"
-    TARGET_S3_BUCKET                 = "${aws_s3_bucket.binaryalert_binaries.id}"
+    CARBON_BLACK_URL                 = var.carbon_black_url
+    CARBON_BLACK_TIMEOUT             = var.carbon_black_timeout
+    ENCRYPTED_CARBON_BLACK_API_TOKEN = var.encrypted_carbon_black_api_token
+    TARGET_S3_BUCKET                 = aws_s3_bucket.binaryalert_binaries.id
   }
 
-  log_retention_days = "${var.lambda_log_retention_days}"
-  tagged_name        = "${var.tagged_name}"
-  alarm_sns_arns     = ["${local.alarm_target}"]
+  log_retention_days = var.lambda_log_retention_days
+  tagged_name        = var.tagged_name
+
+  alarm_errors_threshold = 500
+  alarm_sns_arns         = [local.alarm_target]
 }
 
 // Invoke downloader Lambda from downloader SQS queue.
 resource "aws_lambda_event_source_mapping" "downloader_via_sqs" {
-  count            = "${var.enable_carbon_black_downloader ? 1 : 0}"
-  batch_size       = "${var.download_queue_batch_size}"
-  event_source_arn = "${aws_sqs_queue.downloader_queue.arn}"
-  function_name    = "${module.binaryalert_downloader.alias_arn}"
+  count            = var.enable_carbon_black_downloader ? 1 : 0
+  batch_size       = var.download_queue_batch_size
+  event_source_arn = aws_sqs_queue.downloader_queue[0].arn
+  function_name    = module.binaryalert_downloader.alias_arn
 }
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,8 +1,4 @@
-terraform {
-  required_version = "~> 0.11.7"
-}
-
 provider "aws" {
-  version = "~> 1.30.0"
-  region  = "${var.aws_region}"
+  version = "~> 2.45.0"
+  region  = var.aws_region
 }

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -1,7 +1,7 @@
 /* Module to create the base components for each Lambda function. */
 
 data "aws_iam_policy_document" "lambda_execution_policy" {
-  count = "${var.enabled}"
+  count = var.enabled
 
   statement {
     sid     = "AllowLambdaToAssumeRole"
@@ -16,67 +16,67 @@ data "aws_iam_policy_document" "lambda_execution_policy" {
 
 // Create a custom execution role for each Lambda function.
 resource "aws_iam_role" "role" {
-  count              = "${var.enabled}"
+  count              = var.enabled
   name               = "${var.function_name}_role"
-  assume_role_policy = "${data.aws_iam_policy_document.lambda_execution_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_execution_policy[0].json
 }
 
 // Attach the base IAM policy.
 resource "aws_iam_role_policy_attachment" "attach_base_policy" {
-  count      = "${var.enabled}"
-  role       = "${aws_iam_role.role.name}"
-  policy_arn = "${var.base_policy_arn}"
+  count      = var.enabled
+  role       = aws_iam_role.role[0].name
+  policy_arn = var.base_policy_arn
 }
 
 // Create the Lambda log group.
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
-  count             = "${var.enabled}"
+  count             = var.enabled
   name              = "/aws/lambda/${var.function_name}"
-  retention_in_days = "${var.log_retention_days}"
+  retention_in_days = var.log_retention_days
 
-  tags {
-    Name = "${var.tagged_name}"
+  tags = {
+    Name = var.tagged_name
   }
 }
 
 // Create the Lambda function.
 resource "aws_lambda_function" "function" {
-  count = "${var.enabled}"
+  count = var.enabled
 
-  function_name = "${var.function_name}"
-  description   = "${var.description}"
-  handler       = "${var.handler}"
-  role          = "${aws_iam_role.role.arn}"
+  function_name = var.function_name
+  description   = var.description
+  handler       = var.handler
+  role          = aws_iam_role.role[0].arn
   runtime       = "python3.6"
 
-  memory_size                    = "${var.memory_size_mb}"
-  timeout                        = "${var.timeout_sec}"
-  reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
+  memory_size                    = var.memory_size_mb
+  timeout                        = var.timeout_sec
+  reserved_concurrent_executions = var.reserved_concurrent_executions
 
-  filename         = "${var.filename}"
-  source_code_hash = "${base64sha256(file(var.filename))}"
+  filename         = var.filename
+  source_code_hash = filebase64sha256(var.filename)
   publish          = true
 
   environment {
-    variables = "${var.environment_variables}"
+    variables = var.environment_variables
   }
 
-  tags {
-    Name = "${var.tagged_name}"
+  tags = {
+    Name = var.tagged_name
   }
 }
 
 // Create a Production alias for each Lambda function.
 resource "aws_lambda_alias" "production_alias" {
-  count            = "${var.enabled}"
+  count            = var.enabled
   name             = "Production"
-  function_name    = "${aws_lambda_function.function.arn}"
-  function_version = "${aws_lambda_function.function.version}"
+  function_name    = aws_lambda_function.function[0].arn
+  function_version = aws_lambda_function.function[0].version
 }
 
 // Alarm if the Lambda function has more than the configured number of errors.
 resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
-  count      = "${var.enabled}"
+  count      = var.enabled
   alarm_name = "${var.function_name}_errors"
 
   alarm_description = <<EOF
@@ -84,19 +84,21 @@ ${var.function_name} has a high error rate. Check the CloudWatch logs.
 ${var.alarm_errors_help}
 EOF
 
+
   namespace   = "AWS/Lambda"
   metric_name = "Errors"
   statistic   = "Sum"
 
   dimensions = {
-    FunctionName = "${aws_lambda_function.function.function_name}"
-    Resource     = "${aws_lambda_function.function.function_name}:${aws_lambda_alias.production_alias.name}"
+    FunctionName = aws_lambda_function.function[0].function_name
+    Resource     = "${aws_lambda_function.function[0].function_name}:${aws_lambda_alias.production_alias[0].name}"
   }
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = "${var.alarm_errors_threshold}"
-  period              = "${var.alarm_errors_interval_secs}"
+  threshold           = var.alarm_errors_threshold
+  period              = var.alarm_errors_interval_secs
   evaluation_periods  = 1
 
-  alarm_actions = ["${var.alarm_sns_arns}"]
+  alarm_actions = var.alarm_sns_arns
 }
+

--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -2,25 +2,32 @@
 # https://www.terraform.io/upgrade-guides/0-11.html#referencing-attributes-from-resources-with-count-0
 
 output "alias_arn" {
-  value = "${element(concat(aws_lambda_alias.production_alias.*.arn, list("")), 0)}"
+  value = element(concat(aws_lambda_alias.production_alias.*.arn, [""]), 0)
 }
 
 output "alias_name" {
-  value = "${element(concat(aws_lambda_alias.production_alias.*.name, list("")), 0)}"
+  value = element(concat(aws_lambda_alias.production_alias.*.name, [""]), 0)
 }
 
 output "function_arn" {
-  value = "${element(concat(aws_lambda_function.function.*.arn, list("")), 0)}"
+  value = element(concat(aws_lambda_function.function.*.arn, [""]), 0)
 }
 
 output "function_name" {
-  value = "${element(concat(aws_lambda_function.function.*.function_name, list("")), 0)}"
+  value = element(
+    concat(aws_lambda_function.function.*.function_name, [""]),
+    0,
+  )
 }
 
 output "log_group_name" {
-  value = "${element(concat(aws_cloudwatch_log_group.lambda_log_group.*.name, list("")), 0)}"
+  value = element(
+    concat(aws_cloudwatch_log_group.lambda_log_group.*.name, [""]),
+    0,
+  )
 }
 
 output "role_id" {
-  value = "${element(concat(aws_iam_role.role.*.id, list("")), 0)}"
+  value = element(concat(aws_iam_role.role.*.id, [""]), 0)
 }
+

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -26,6 +26,7 @@ variable "memory_size_mb" {
 Memory allocated to the Lambda function (128 - 1536 MB).
 Lambda also allocates CPU and network resources in proportion to the configured memory.
 EOF
+
 }
 
 variable "timeout_sec" {
@@ -41,7 +42,7 @@ variable "reserved_concurrent_executions" {
 }
 
 variable "environment_variables" {
-  type        = "map"
+  type        = map(string)
   description = "Map of environment variables available to the running Lambda function"
 }
 
@@ -60,10 +61,11 @@ variable "alarm_errors_help" {
 
 variable "alarm_errors_threshold" {
   description = "If at least this many errors occur within alarm_errors_interval_secs, a metric alarm will trigger"
+
   # The error threshold has been increased significantly; this is due to a recent change that
   # retries HTTP 404s by raising errors on Lambda, designed to accommodate for race conditions
   # on the availability of the binary resource.
-  default     = 250
+  default = 250
 }
 
 variable "alarm_errors_interval_secs" {
@@ -72,6 +74,7 @@ variable "alarm_errors_interval_secs" {
 }
 
 variable "alarm_sns_arns" {
-  type        = "list"
+  type        = list(string)
   description = "A list of SNS topic ARNs which will be notified when a metric alarm triggers"
 }
+

--- a/terraform/modules/lambda/versions.tf
+++ b/terraform/modules/lambda/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = "~> 0.12.9"
+}

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -5,12 +5,13 @@ resource "aws_sns_topic" "yara_match_alerts" {
 
 // If a file does NOT match any YARA rules, notify this SNS topic.
 resource "aws_sns_topic" "no_yara_match" {
-  count = "${var.enable_negative_match_alerts ? 1 : 0}"
+  count = var.enable_negative_match_alerts ? 1 : 0
   name  = "${var.name_prefix}_binaryalert_no_yara_match"
 }
 
 // CloudWatch metric alarms notify this SNS topic (created only if an existing one is not specified)
 resource "aws_sns_topic" "metric_alarms" {
-  count = "${var.metric_alarm_sns_topic_arn == "" ? 1 : 0}"
+  count = var.metric_alarm_sns_topic_arn == "" ? 1 : 0
   name  = "${var.name_prefix}_binaryalert_metric_alarms"
 }
+

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -1,15 +1,15 @@
 // Analysis queue - S3 objects which need to be analyzed
 resource "aws_sqs_queue" "analyzer_queue" {
   name                      = "${var.name_prefix}_binaryalert_analyzer_queue"
-  kms_master_key_id         = "${aws_kms_key.sse_sqs.arn}"
-  message_retention_seconds = "${var.analyze_queue_retention_secs}"
+  kms_master_key_id         = aws_kms_key.sse_sqs.arn
+  message_retention_seconds = var.analyze_queue_retention_secs
 
   // When a message is received, it will be invisible to other consumers for this long.
   // Set to just a few seconds after the lambda analyzer would timeout.
-  visibility_timeout_seconds = "${format("%d", var.lambda_analyze_timeout_sec + 2)}"
+  visibility_timeout_seconds = format("%d", var.lambda_analyze_timeout_sec + 2)
 
-  tags {
-    Name = "${var.tagged_name}"
+  tags = {
+    Name = var.tagged_name
   }
 }
 
@@ -23,39 +23,39 @@ data "aws_iam_policy_document" "analyzer_queue_policy" {
     }
 
     actions   = ["sqs:SendMessage"]
-    resources = ["${aws_sqs_queue.analyzer_queue.arn}"]
+    resources = [aws_sqs_queue.analyzer_queue.arn]
 
     // Allow only the BinaryAlert S3 bucket to notify the SQS queue.
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values   = ["${aws_s3_bucket.binaryalert_binaries.arn}"]
+      values   = [aws_s3_bucket.binaryalert_binaries.arn]
     }
   }
 }
 
 // Allow analyzer queue to be sent messages from the BinaryAlert S3 bucket.
 resource "aws_sqs_queue_policy" "analyzer_queue_policy" {
-  queue_url = "${aws_sqs_queue.analyzer_queue.id}"
-  policy    = "${data.aws_iam_policy_document.analyzer_queue_policy.json}"
+  queue_url = aws_sqs_queue.analyzer_queue.id
+  policy    = data.aws_iam_policy_document.analyzer_queue_policy.json
 }
 
 // Downloader queue - MD5s to download from CarbonBlack
 resource "aws_sqs_queue" "downloader_queue" {
-  count                     = "${var.enable_carbon_black_downloader ? 1 : 0}"
+  count                     = var.enable_carbon_black_downloader ? 1 : 0
   name                      = "${var.name_prefix}_binaryalert_downloader_queue"
-  kms_master_key_id         = "${aws_kms_key.sse_sqs.arn}"
-  message_retention_seconds = "${var.download_queue_retention_secs}"
+  kms_master_key_id         = aws_kms_key.sse_sqs.arn
+  message_retention_seconds = var.download_queue_retention_secs
 
   // When a message is received, it will be invisible to other consumers for this long.
   // Set to just a few seconds after the downloader would timeout.
-  visibility_timeout_seconds = "${format("%d", var.lambda_download_timeout_sec + 2)}"
+  visibility_timeout_seconds = format("%d", var.lambda_download_timeout_sec + 2)
 
   // If a message fails to be processed after the set number of retries, it is delivered to the DLQ.
-  redrive_policy = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.dead_letter_queue.arn}\",\"maxReceiveCount\":${var.download_queue_max_receives}}"
+  redrive_policy = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.dead_letter_queue[0].arn}\",\"maxReceiveCount\":${var.download_queue_max_receives}}"
 
-  tags {
-    Name = "${var.tagged_name}"
+  tags = {
+    Name = var.tagged_name
   }
 }
 
@@ -63,13 +63,14 @@ resource "aws_sqs_queue" "downloader_queue" {
 // Messages sent here are meant for human consumption (debugging) and are retained for 14 days.
 // This is only used for the downloader queue (for now).
 resource "aws_sqs_queue" "dead_letter_queue" {
-  count                     = "${var.enable_carbon_black_downloader ? 1 : 0}"
+  count                     = var.enable_carbon_black_downloader ? 1 : 0
   name                      = "${var.name_prefix}_binaryalert_sqs_dead_letter_queue"
   message_retention_seconds = 1209600
 
-  kms_master_key_id = "${aws_kms_key.sse_sqs.arn}"
+  kms_master_key_id = aws_kms_key.sse_sqs.arn
 
-  tags {
-    Name = "${var.tagged_name}"
+  tags = {
+    Name = var.tagged_name
   }
 }
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,48 +1,100 @@
 /* See terraform.tfvars for descriptions of each of the variables. */
 
-variable "aws_account_id" {}
-variable "aws_region" {}
-variable "name_prefix" {}
+variable "aws_account_id" {
+}
 
-variable "enable_carbon_black_downloader" {}
-variable "carbon_black_url" {}
-variable "encrypted_carbon_black_api_token" {}
+variable "aws_region" {
+}
 
-variable "s3_log_bucket" {}
-variable "s3_log_prefix" {}
-variable "s3_log_expiration_days" {}
-variable "lambda_log_retention_days" {}
+variable "name_prefix" {
+}
 
-variable "tagged_name" {}
+variable "enable_carbon_black_downloader" {
+}
 
-variable "metric_alarm_sns_topic_arn" {}
-variable "expected_analysis_frequency_minutes" {}
+variable "carbon_black_url" {
+}
 
-variable "dynamo_read_capacity" {}
-variable "dynamo_write_capacity" {}
+variable "carbon_black_timeout" {
+}
 
-variable "lambda_analyze_memory_mb" {}
-variable "lambda_analyze_timeout_sec" {}
-variable "lambda_analyze_concurrency_limit" {}
-variable "lambda_download_memory_mb" {}
-variable "lambda_download_timeout_sec" {}
-variable "lambda_download_concurrency_limit" {}
+variable "encrypted_carbon_black_api_token" {
+}
 
-variable "force_destroy" {}
+variable "s3_log_bucket" {
+}
+
+variable "s3_log_prefix" {
+}
+
+variable "s3_log_expiration_days" {
+}
+
+variable "lambda_log_retention_days" {
+}
+
+variable "tagged_name" {
+}
+
+variable "metric_alarm_sns_topic_arn" {
+}
+
+variable "expected_analysis_frequency_minutes" {
+}
+
+variable "dynamo_read_capacity" {
+}
+
+variable "dynamo_write_capacity" {
+}
+
+variable "lambda_analyze_memory_mb" {
+}
+
+variable "lambda_analyze_timeout_sec" {
+}
+
+variable "lambda_analyze_concurrency_limit" {
+}
+
+variable "lambda_download_memory_mb" {
+}
+
+variable "lambda_download_timeout_sec" {
+}
+
+variable "lambda_download_concurrency_limit" {
+}
+
+variable "force_destroy" {
+}
 
 variable "external_s3_bucket_resources" {
-  type = "list"
+  type = list(string)
 }
 
 variable "external_kms_key_resources" {
-  type = "list"
+  type = list(string)
 }
 
-variable "enable_negative_match_alerts" {}
+variable "enable_negative_match_alerts" {
+}
 
-variable "analyze_queue_batch_size" {}
-variable "download_queue_batch_size" {}
-variable "analyze_queue_retention_secs" {}
-variable "download_queue_retention_secs" {}
-variable "objects_per_retro_message" {}
-variable "download_queue_max_receives" {}
+variable "analyze_queue_batch_size" {
+}
+
+variable "download_queue_batch_size" {
+}
+
+variable "analyze_queue_retention_secs" {
+}
+
+variable "download_queue_retention_secs" {
+}
+
+variable "objects_per_retro_message" {
+}
+
+variable "download_queue_max_receives" {
+}
+

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 0.12.9"
+}


### PR DESCRIPTION
to: @airbnb/binaryalert-maintainers
size: medium

## Changes

* Upgrades Terraform syntax on all modules to 0.12
* Upgrades `pyhcl` to 0.4.0 to be Terraform 0.12 compatible

## Testing

I sync'd internally and tested a `terraform plan`, which works.... **with some tweaking**.
