### PR TITLE
Fixed cve_rules folder name according to latest Yara-Rule repo structure

### DIFF
--- a/rules/rule_sources.json
+++ b/rules/rule_sources.json
@@ -9,7 +9,7 @@
     {
       "url": "https://github.com/YARA-Rules/rules.git",
       "include": [
-        "CVE_Rules/*"
+        "cve_rules/*"
       ]
     }
   ]


### PR DESCRIPTION
to: @airbnb/binaryalert-maintainers
cc: <optional-cc-to-specific-users>
size: small|medium|large
resolves #<related-issue-goes-here>

## Background

Yara rules were not fetched from the defined folder because the repo structure changed and folder were renamed.

## Changes

* fixed the folder name according to current structure

## Testing

Tested on my local system. Screenshot attached.

![image](https://user-images.githubusercontent.com/2002879/78031162-c832c500-7380-11ea-91c7-b826c1334b58.png)
