### PR TITLE
Updates getting-started.rst

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -58,6 +58,8 @@ Download BinaryAlert
   $ cd binaryalert
   $ python3.6 -m venv venv
   $ source venv/bin/activate
+  
+.. note:: If brew installed the latest python and you still don't have python3.6, you can download it from ``https://www.python.org/downloads/release/python-365/``, then retry the commands above.
 
 3. Install the BinaryAlert requirements:
 
@@ -72,6 +74,8 @@ Download BinaryAlert
 .. code-block:: bash
 
   $ ./manage.py unit_test
+
+.. note:: If you run into an error ``ModuleNotFoundError: No module named 'boto3'``, try ``python3.6 manage.py unit_test``.
 
 Set AWS Credentials
 -------------------


### PR DESCRIPTION
Since the latest brew python is now at 3.9.4, it throws errors when executing pip3 install -r requirements.txt. Hence I added a couple lines for notes in case someone runs into these issues.
Cheers.

to: @airbnb/binaryalert-maintainers
cc: <optional-cc-to-specific-users>
size: small|medium|large
resolves #<related-issue-goes-here>

## Background

Documentation enhancement to make sure the correct version of python is installed and if not, where to get python 3.6.x.


## Changes

Adds 2 notes to help users in case they run into similar issues.

## Testing

Ran the additional commands added to the document locally and it passed. 