### PR TITLE
require MZ to fix fp

### DIFF
--- a/rules/public/hacktool/windows/hacktool_windows_mimikatz_modules.yara
+++ b/rules/public/hacktool/windows/hacktool_windows_mimikatz_modules.yara
@@ -14,5 +14,6 @@ rule hacktool_windows_mimikatz_modules
         $s2 = "mimidrv" fullword ascii wide
         $s3 = "mimilove" fullword ascii wide
     condition:
-        any of them
+        uint16(0)==0x5a4d
+        and any of them
 }


### PR DESCRIPTION
to: @airbnb/binaryalert-maintainers
cc: <optional-cc-to-specific-users>
size: small
resolves #<related-issue-goes-here>

## Background

rule produces false positives on e.g. debians
/usr/share/doc/hashcat-data/examples/example.dict

## Changes

require MZ bytes 

## Testing

running yara on mimikatz.exe
